### PR TITLE
Refine admin managers and featured badges

### DIFF
--- a/app/admin/(dashboard)/case-studies/case-study-manager.tsx
+++ b/app/admin/(dashboard)/case-studies/case-study-manager.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 
+import { Modal } from "@/components/admin/modal";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -22,11 +23,24 @@ export function CaseStudyManager({
   status?: string;
 }) {
   const [selectedId, setSelectedId] = useState<string>("");
+  const [query, setQuery] = useState("");
   const [mdxFilter, setMdxFilter] = useState("");
+  const [open, setOpen] = useState(false);
+
   const selected = useMemo(
-    () => caseStudies.find((study) => study.id === selectedId),
+    () => caseStudies.find((study) => study.id === selectedId) ?? null,
     [caseStudies, selectedId],
   );
+
+  const filtered = useMemo(() => {
+    const term = query.trim().toLowerCase();
+    if (!term) return caseStudies;
+    return caseStudies.filter((study) =>
+      [study.title, study.slug, study.vertical, study.summary]
+        .concat(study.tags ?? [])
+        .some((value) => value?.toLowerCase().includes(term)),
+    );
+  }, [caseStudies, query]);
 
   const copyExport = async () => {
     try {
@@ -36,6 +50,17 @@ export function CaseStudyManager({
     }
   };
 
+  const handleOpen = (id?: string) => {
+    setSelectedId(id ?? "");
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    setSelectedId("");
+    setMdxFilter("");
+  };
+
   return (
     <div className="space-y-6">
       <header className="space-y-2">
@@ -43,27 +68,19 @@ export function CaseStudyManager({
           <div>
             <h1 className="text-3xl font-semibold">Case studies</h1>
             <p className="text-muted-foreground text-sm">
-              Manage long-form narratives that power the case studies section and related project
-              cross-links.
+              Manage narratives that power the case studies section and related cross-links.
             </p>
           </div>
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-          <label className="text-sm font-medium" htmlFor="case-study-selector">
-            Select existing study
-          </label>
-          <select
-              id="case-study-selector"
-              value={selectedId}
-              onChange={(event) => setSelectedId(event.target.value)}
-              className="border-input bg-background focus:ring-ring w-64 rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-offset-2"
-            >
-              <option value="">Create new case study…</option>
-              {caseStudies.map((study) => (
-                <option key={study.id} value={study.id}>
-                  {study.title}
-                </option>
-              ))}
-            </select>
+          <div className="flex items-center gap-3">
+            <Input
+              placeholder="Search title, slug, tag..."
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              className="w-64"
+            />
+            <Button size="sm" onClick={() => handleOpen()}>
+              Add case study
+            </Button>
           </div>
         </div>
         <div className="flex flex-wrap gap-2">
@@ -82,143 +99,184 @@ export function CaseStudyManager({
 
       <Card>
         <CardHeader>
-          <CardTitle>{selected ? "Edit case study" : "Add case study"}</CardTitle>
-          <CardDescription>Manage metadata and content body below.</CardDescription>
+          <CardTitle>Case studies</CardTitle>
+          <CardDescription>Filter to find a study, then edit its metadata and linked MDX.</CardDescription>
         </CardHeader>
-        <CardContent className="space-y-4">
-          <form key={selected?.id ?? "create"} action={upsertCaseStudy} className={FORM_GRID}>
-            <input type="hidden" name="id" value={selected?.id ?? ""} />
-            <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium" htmlFor="title">
-                Title
-              </label>
-              <Input id="title" name="title" defaultValue={selected?.title ?? ""} required />
-            </div>
-            <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium" htmlFor="hero_image">Cover image</label>
-              <input id="hero_image" name="hero_image" type="file" accept="image/*" className="text-sm" />
-              {selected?.hero_url ? (
-                <p className="text-xs text-muted-foreground">Current: {selected.hero_url}</p>
-              ) : null}
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="slug">
-                Slug
-              </label>
-              <Input id="slug" name="slug" defaultValue={selected?.slug ?? ""} required />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="vertical">
-                Vertical
-              </label>
-              <select
-                id="vertical"
-                name="vertical"
-                defaultValue={selected?.vertical ?? "ai-security"}
-                className="border-input bg-background focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-offset-2"
-              >
-                <option value="ai-security">AI Security</option>
-                <option value="secure-devops">Secure DevOps</option>
-                <option value="soc">SOC</option>
-              </select>
-            </div>
-            <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium" htmlFor="summary">
-                Summary
-              </label>
-              <Textarea
-                id="summary"
-                name="summary"
-                defaultValue={selected?.summary ?? ""}
-                rows={3}
-                required
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="tags">
-                Tags (comma separated)
-              </label>
-              <Input
-                id="tags"
-                name="tags"
-                defaultValue={selected ? selected.tags.join(", ") : ""}
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="hero_url">
-                Hero image URL
-              </label>
-              <Input id="hero_url" name="hero_url" defaultValue={selected?.hero_url ?? ""} />
-            </div>
-            <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium" htmlFor="body_path">Body path (managed)</label>
-              <Input id="body_path" name="body_path" defaultValue={selected?.body_path ?? ""} readOnly disabled />
-              <p className="text-xs text-muted-foreground">Set automatically when creating or linking an MDX document.</p>
-            </div>
-            <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium" htmlFor="mdx_content">Content (MDX)</label>
-              <Textarea id="mdx_content" name="mdx_content" rows={10} placeholder={selected?.body_path ? "Leave blank to keep existing MDX; paste to replace" : "Write case study in MDX here"} />
-              <p className="text-xs text-muted-foreground">On save, a doc will be created at case-studies/&lt;slug&gt;.mdx if not present, or updated if it exists.</p>
-            </div>
-            <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium" htmlFor="link_key">Link existing MDX</label>
-              <Input placeholder="Quick filter..." value={mdxFilter} onChange={(e) => setMdxFilter(e.target.value)} />
-              <select id="link_key" name="link_key" defaultValue="" className="border-input bg-background focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-offset-2">
-                <option value="">— Select available document —</option>
-                {availableDocs.filter((d) => d.key.toLowerCase().includes(mdxFilter.toLowerCase())).map((doc) => (
-                  <option key={doc.id} value={doc.key}>{doc.key}</option>
+        <CardContent>
+          <div className="max-h-[60vh] overflow-auto rounded-md border">
+            <table className="w-full text-left text-sm">
+              <thead className="sticky top-0 bg-muted/40">
+                <tr className="border-b">
+                  <th className="px-3 py-2">Title</th>
+                  <th className="px-3 py-2">Slug</th>
+                  <th className="px-3 py-2">Vertical</th>
+                  <th className="px-3 py-2">Status</th>
+                  <th className="px-3 py-2">Featured</th>
+                  <th className="px-3 py-2">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((study) => (
+                  <tr key={study.id} className="border-b last:border-0">
+                    <td className="px-3 py-2">{study.title}</td>
+                    <td className="px-3 py-2">{study.slug}</td>
+                    <td className="px-3 py-2">{study.vertical}</td>
+                    <td className="px-3 py-2 capitalize">{study.status}</td>
+                    <td className="px-3 py-2">{study.featured ? "Yes" : "No"}</td>
+                    <td className="px-3 py-2">
+                      <Button size="sm" variant="outline" onClick={() => handleOpen(study.id)}>
+                        Edit
+                      </Button>
+                    </td>
+                  </tr>
                 ))}
-              </select>
-              <p className="text-xs text-muted-foreground">Only unlinked documents are listed. Linking ignores the Content field.</p>
-            </div>
-            <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium" htmlFor="metrics">
-                Metrics (one per line: Metric|Value)
-              </label>
-              <Textarea
-                id="metrics"
-                name="metrics"
-                defaultValue={formatMetrics(selected)}
-                rows={4}
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="status">
-                Status
-              </label>
-              <select
-                id="status"
-                name="status"
-                defaultValue={selected?.status ?? "draft"}
-                className="border-input bg-background focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-offset-2"
-              >
-                <option value="draft">Draft</option>
-                <option value="published">Published</option>
-              </select>
-            </div>
-            <div className="flex items-center gap-2 md:col-span-2">
-              <input id="featured" name="featured" type="checkbox" defaultChecked={selected?.featured ?? false} />
-              <label htmlFor="featured" className="text-sm font-medium">Featured (max 6)</label>
-            </div>
-            <div className="flex justify-end gap-2 md:col-span-2">
-              {selected ? (
-                <Button type="button" variant="outline" onClick={() => setSelectedId("")}>
-                  Clear selection
-                </Button>
-              ) : null}
-              <Button type="submit">{selected ? "Save case study" : "Create case study"}</Button>
-            </div>
-          </form>
-          {selected ? (
-            <form action={deleteCaseStudy} className="flex justify-end">
-              <input type="hidden" name="id" value={selected.id} />
-              <Button variant="destructive" type="submit">
-                Delete case study
-              </Button>
-            </form>
-          ) : null}
+              </tbody>
+            </table>
+          </div>
         </CardContent>
       </Card>
+
+      <Modal open={open} onClose={handleClose} title={selected ? "Edit case study" : "Add case study"}>
+        <form key={selected?.id ?? "create"} action={upsertCaseStudy} className={FORM_GRID}>
+          <input type="hidden" name="id" value={selected?.id ?? ""} />
+          <div className="space-y-2 md:col-span-2">
+            <label className="text-sm font-medium" htmlFor="title">
+              Title
+            </label>
+            <Input id="title" name="title" defaultValue={selected?.title ?? ""} required />
+          </div>
+          <div className="space-y-2 md:col-span-2">
+            <label className="text-sm font-medium" htmlFor="hero_image">Cover image</label>
+            <input id="hero_image" name="hero_image" type="file" accept="image/*" className="text-sm" />
+            {selected?.hero_url ? (
+              <p className="text-xs text-muted-foreground">Current: {selected.hero_url}</p>
+            ) : null}
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="slug">
+              Slug
+            </label>
+            <Input id="slug" name="slug" defaultValue={selected?.slug ?? ""} required />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="vertical">
+              Vertical
+            </label>
+            <select
+              id="vertical"
+              name="vertical"
+              defaultValue={selected?.vertical ?? "ai-security"}
+              className="border-input bg-background focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-offset-2"
+            >
+              <option value="ai-security">AI Security</option>
+              <option value="secure-devops">Secure DevOps</option>
+              <option value="soc">SOC</option>
+            </select>
+          </div>
+          <div className="space-y-2 md:col-span-2">
+            <label className="text-sm font-medium" htmlFor="summary">
+              Summary
+            </label>
+            <Textarea id="summary" name="summary" defaultValue={selected?.summary ?? ""} rows={3} required />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="tags">
+              Tags (comma separated)
+            </label>
+            <Input id="tags" name="tags" defaultValue={selected ? selected.tags.join(", ") : ""} />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="hero_url">
+              Hero image URL
+            </label>
+            <Input id="hero_url" name="hero_url" defaultValue={selected?.hero_url ?? ""} />
+          </div>
+          <div className="space-y-2 md:col-span-2">
+            <label className="text-sm font-medium" htmlFor="body_path">Body path (managed)</label>
+            <Input id="body_path" name="body_path" defaultValue={selected?.body_path ?? ""} readOnly disabled />
+            <p className="text-xs text-muted-foreground">Set automatically when creating or linking an MDX document.</p>
+          </div>
+          <div className="space-y-2 md:col-span-2">
+            <label className="text-sm font-medium" htmlFor="mdx_content">Content (MDX)</label>
+            <Textarea
+              id="mdx_content"
+              name="mdx_content"
+              rows={10}
+              placeholder={selected?.body_path ? "Leave blank to keep existing MDX; paste to replace" : "Write case study in MDX here"}
+            />
+            <p className="text-xs text-muted-foreground">On save, a doc will be created at case-studies/&lt;slug&gt;.mdx if not present, or updated if it exists.</p>
+          </div>
+          <div className="space-y-2 md:col-span-2">
+            <label className="text-sm font-medium" htmlFor="link_key">Link existing MDX</label>
+            <Input placeholder="Quick filter..." value={mdxFilter} onChange={(event) => setMdxFilter(event.target.value)} />
+            <select
+              id="link_key"
+              name="link_key"
+              defaultValue=""
+              className="border-input bg-background focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-offset-2"
+            >
+              <option value="">— Select available document —</option>
+              {availableDocs
+                .filter((doc) => doc.key.toLowerCase().includes(mdxFilter.toLowerCase()))
+                .map((doc) => (
+                  <option key={doc.id} value={doc.key}>
+                    {doc.key}
+                  </option>
+                ))}
+            </select>
+            <p className="text-xs text-muted-foreground">Only unlinked documents are listed. Linking ignores the Content field.</p>
+          </div>
+          <div className="space-y-2 md:col-span-2">
+            <label className="text-sm font-medium" htmlFor="metrics">
+              Metrics (one per line: Metric|Value)
+            </label>
+            <Textarea id="metrics" name="metrics" defaultValue={formatMetrics(selected ?? undefined)} rows={4} />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="status">
+              Status
+            </label>
+            <select
+              id="status"
+              name="status"
+              defaultValue={selected?.status ?? "draft"}
+              className="border-input bg-background focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-offset-2"
+            >
+              <option value="draft">Draft</option>
+              <option value="published">Published</option>
+            </select>
+          </div>
+          <div className="flex items-center gap-2">
+            <input id="featured" name="featured" type="checkbox" defaultChecked={selected?.featured ?? false} />
+            <label htmlFor="featured" className="text-sm font-medium">
+              Featured (max 6)
+            </label>
+          </div>
+          <div className="flex items-center justify-between gap-2 md:col-span-2">
+            {selected ? (
+              <form
+                action={deleteCaseStudy}
+                onSubmit={(event) => {
+                  if (!confirm("Delete this case study?")) event.preventDefault();
+                }}
+              >
+                <input type="hidden" name="id" value={selected.id} />
+                <Button variant="destructive" type="submit">
+                  Delete case study
+                </Button>
+              </form>
+            ) : (
+              <span />
+            )}
+            <div className="flex gap-2">
+              <Button type="button" variant="outline" onClick={handleClose}>
+                Cancel
+              </Button>
+              <Button type="submit">{selected ? "Save case study" : "Create case study"}</Button>
+            </div>
+          </div>
+        </form>
+      </Modal>
 
       <Card>
         <CardHeader>
@@ -244,7 +302,7 @@ export function CaseStudyManager({
   );
 }
 
-function formatMetrics(study: CaseStudy | undefined) {
+function formatMetrics(study: CaseStudy | null | undefined) {
   if (!study?.metrics) return "";
   return Object.entries(study.metrics)
     .map(([metric, value]) => `${metric}|${value}`)

--- a/app/admin/(dashboard)/contact-links/contact-links-manager.tsx
+++ b/app/admin/(dashboard)/contact-links/contact-links-manager.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 
+import { Modal } from "@/components/admin/modal";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -9,122 +10,164 @@ import type { ContactLink } from "@/lib/supabase/types";
 
 import { deleteContactLink, upsertContactLink } from "./actions";
 
+const FORM_GRID = "grid gap-3 md:grid-cols-2";
+
 export function ContactLinksManager({ links, status }: { links: ContactLink[]; status?: string }) {
   const [selectedId, setSelectedId] = useState<string>("");
-  const selected = useMemo(() => links.find((link) => link.id === selectedId), [links, selectedId]);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const selected = useMemo(() => links.find((link) => link.id === selectedId) ?? null, [links, selectedId]);
+
+  const filtered = useMemo(() => {
+    const term = query.trim().toLowerCase();
+    if (!term) return links;
+    return links.filter((link) =>
+      [link.label, link.url, link.category ?? "", link.icon ?? ""].some((value) =>
+        value.toLowerCase().includes(term),
+      ),
+    );
+  }, [links, query]);
+
+  const handleOpen = (id?: string) => {
+    setSelectedId(id ?? "");
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    setSelectedId("");
+  };
 
   return (
     <div className="space-y-6">
       <header className="space-y-2">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
           <div>
-            <h1 className="text-3xl font-semibold">Contact links</h1>
+            <h1 className="text-3xl font-semibold">Contact methods</h1>
             <p className="text-muted-foreground text-sm">
               Manage the destinations surfaced on the public contact page.
             </p>
           </div>
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-            <label className="text-sm font-medium" htmlFor="contact-link-selector">
-              Select link
-            </label>
-            <select
-              id="contact-link-selector"
-              value={selectedId}
-              onChange={(event) => setSelectedId(event.target.value)}
-              className="border-input bg-background focus:ring-ring w-64 rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-offset-2"
-            >
-              <option value="">Create new link…</option>
-              {links.map((link) => (
-                <option key={link.id} value={link.id}>
-                  {link.label}
-                </option>
-              ))}
-            </select>
+          <div className="flex items-center gap-3">
+            <Input
+              placeholder="Search label, url, category..."
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              className="w-64"
+            />
+            <Button size="sm" onClick={() => handleOpen()}>
+              Add method
+            </Button>
           </div>
         </div>
         {status === "success" ? (
-          <p className="text-sm text-emerald-600">Contact link saved.</p>
+          <p className="text-sm text-emerald-600">Contact method saved.</p>
         ) : status === "deleted" ? (
-          <p className="text-sm text-emerald-600">Contact link deleted.</p>
+          <p className="text-sm text-emerald-600">Contact method deleted.</p>
         ) : null}
       </header>
 
       <Card>
         <CardHeader>
-          <CardTitle>{selected ? "Edit contact link" : "Add contact link"}</CardTitle>
-          <CardDescription>Links are ordered by the `order_index` ascending.</CardDescription>
+          <CardTitle>Directory</CardTitle>
+          <CardDescription>Use the table to quickly locate and edit entries.</CardDescription>
         </CardHeader>
-        <CardContent className="space-y-4">
-          <form
-            key={selected?.id ?? "create"}
-            action={upsertContactLink}
-            className="grid gap-3 md:grid-cols-2"
-          >
-            <input type="hidden" name="id" value={selected?.id ?? ""} />
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="label">
-                Label
-              </label>
-              <Input id="label" name="label" defaultValue={selected?.label ?? ""} required />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="url">
-                URL / mailto
-              </label>
-              <Input id="url" name="url" defaultValue={selected?.url ?? ""} required />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="category">
-                Category
-              </label>
-              <Input
-                id="category"
-                name="category"
-                defaultValue={selected?.category ?? ""}
-                placeholder="primary, social, etc."
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="icon">
-                Icon
-              </label>
-              <Input
-                id="icon"
-                name="icon"
-                defaultValue={selected?.icon ?? ""}
-                placeholder="github, linkedin"
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="order_index">
-                Order index
-              </label>
-              <Input
-                id="order_index"
-                name="order_index"
-                type="number"
-                defaultValue={selected?.order_index ?? links.length}
-              />
-            </div>
-            <div className="flex justify-end gap-2 md:col-span-2">
-              {selected ? (
-                <Button type="button" variant="outline" onClick={() => setSelectedId("")}>
-                  Clear selection
-                </Button>
-              ) : null}
-              <Button type="submit">{selected ? "Save link" : "Create link"}</Button>
-            </div>
-          </form>
-          {selected ? (
-            <form action={deleteContactLink} className="flex justify-end">
-              <input type="hidden" name="id" value={selected.id} />
-              <Button variant="destructive" type="submit">
-                Delete contact link
-              </Button>
-            </form>
-          ) : null}
+        <CardContent>
+          <div className="max-h-[60vh] overflow-auto rounded-md border">
+            <table className="w-full text-left text-sm">
+              <thead className="sticky top-0 bg-muted/40">
+                <tr className="border-b">
+                  <th className="px-3 py-2">Label</th>
+                  <th className="px-3 py-2">URL</th>
+                  <th className="px-3 py-2">Category</th>
+                  <th className="px-3 py-2">Order</th>
+                  <th className="px-3 py-2">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((link) => (
+                  <tr key={link.id} className="border-b last:border-0">
+                    <td className="px-3 py-2">{link.label}</td>
+                    <td className="px-3 py-2 break-all">{link.url}</td>
+                    <td className="px-3 py-2">{link.category ?? "—"}</td>
+                    <td className="px-3 py-2">{link.order_index}</td>
+                    <td className="px-3 py-2">
+                      <Button size="sm" variant="outline" onClick={() => handleOpen(link.id)}>
+                        Edit
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </CardContent>
       </Card>
+
+      <Modal open={open} onClose={handleClose} title={selected ? "Edit method" : "Add method"}>
+        <form key={selected?.id ?? "create"} action={upsertContactLink} className={FORM_GRID}>
+          <input type="hidden" name="id" value={selected?.id ?? ""} />
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="label">
+              Label
+            </label>
+            <Input id="label" name="label" defaultValue={selected?.label ?? ""} required />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="url">
+              URL / mailto
+            </label>
+            <Input id="url" name="url" defaultValue={selected?.url ?? ""} required />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="category">
+              Category
+            </label>
+            <Input id="category" name="category" defaultValue={selected?.category ?? ""} placeholder="primary, social, etc." />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="icon">
+              Icon
+            </label>
+            <Input id="icon" name="icon" defaultValue={selected?.icon ?? ""} placeholder="github, linkedin" />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="order_index">
+              Order index
+            </label>
+            <Input
+              id="order_index"
+              name="order_index"
+              type="number"
+              defaultValue={selected?.order_index ?? links.length}
+            />
+          </div>
+          <div className="flex items-center justify-between gap-2 md:col-span-2">
+            {selected ? (
+              <form
+                action={deleteContactLink}
+                onSubmit={(event) => {
+                  if (!confirm("Delete this contact method?")) event.preventDefault();
+                }}
+              >
+                <input type="hidden" name="id" value={selected.id} />
+                <Button variant="destructive" type="submit">
+                  Delete
+                </Button>
+              </form>
+            ) : (
+              <span />
+            )}
+            <div className="flex gap-2">
+              <Button type="button" variant="outline" onClick={handleClose}>
+                Cancel
+              </Button>
+              <Button type="submit">{selected ? "Save" : "Create"}</Button>
+            </div>
+          </div>
+        </form>
+      </Modal>
     </div>
   );
 }

--- a/app/admin/(dashboard)/projects/project-manager.tsx
+++ b/app/admin/(dashboard)/projects/project-manager.tsx
@@ -2,23 +2,37 @@
 
 import { useMemo, useState } from "react";
 
+import { Modal } from "@/components/admin/modal";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import type { Project } from "@/lib/supabase/types";
 
-import { deleteProject, importProjects, upsertProject, toggleProjectFeatured } from "./actions";
+import { deleteProject, importProjects, toggleProjectFeatured, upsertProject } from "./actions";
 
 const FORM_GRID = "grid gap-3 md:grid-cols-2";
 
 export function ProjectManager({ projects, status }: { projects: Project[]; status?: string }) {
   const [selectedId, setSelectedId] = useState<string>("");
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
 
   const selected = useMemo(
-    () => projects.find((project) => project.id === selectedId),
+    () => projects.find((project) => project.id === selectedId) ?? null,
     [projects, selectedId],
   );
+
+  const filtered = useMemo(() => {
+    const term = query.trim().toLowerCase();
+    if (!term) return projects;
+    return projects.filter((project) =>
+      [project.title, project.slug, project.vertical, project.summary]
+        .concat(project.tags ?? [])
+        .concat(project.tech_stack ?? [])
+        .some((value) => value?.toLowerCase().includes(term)),
+    );
+  }, [projects, query]);
 
   const copyExport = async () => {
     try {
@@ -26,6 +40,16 @@ export function ProjectManager({ projects, status }: { projects: Project[]; stat
     } catch (error) {
       console.error("Unable to copy projects export", error);
     }
+  };
+
+  const handleOpen = (id?: string) => {
+    setSelectedId(id ?? "");
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    setSelectedId("");
   };
 
   return (
@@ -39,13 +63,15 @@ export function ProjectManager({ projects, status }: { projects: Project[]; stat
             </p>
           </div>
           <div className="flex items-center gap-3">
-            <input
+            <Input
               placeholder="Search title, slug, tag..."
-              className="w-64 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
-              onChange={(e) => setSelectedId(e.target.value)}
-              style={{ display: "none" }}
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              className="w-64"
             />
-            <Button size="sm" onClick={() => { setSelectedId(""); setOpen(true); }}>Add project</Button>
+            <Button size="sm" onClick={() => handleOpen()}>
+              Add project
+            </Button>
           </div>
         </div>
         <div className="flex flex-wrap gap-2">
@@ -64,8 +90,8 @@ export function ProjectManager({ projects, status }: { projects: Project[]; stat
 
       <Card>
         <CardHeader>
-          <CardTitle>List</CardTitle>
-          <CardDescription>Click Edit to modify; use Add to create a project.</CardDescription>
+          <CardTitle>Projects</CardTitle>
+          <CardDescription>Use the table to filter, feature, and edit individual projects.</CardDescription>
         </CardHeader>
         <CardContent>
           <div className="max-h-[60vh] overflow-auto rounded-md border">
@@ -81,20 +107,24 @@ export function ProjectManager({ projects, status }: { projects: Project[]; stat
                 </tr>
               </thead>
               <tbody>
-                {projects.map((p) => (
-                  <tr key={p.id} className="border-b last:border-0">
-                    <td className="px-3 py-2">{p.title}</td>
-                    <td className="px-3 py-2">{p.slug}</td>
-                    <td className="px-3 py-2">{p.vertical}</td>
-                    <td className="px-3 py-2 capitalize">{p.status}</td>
+                {filtered.map((project) => (
+                  <tr key={project.id} className="border-b last:border-0">
+                    <td className="px-3 py-2">{project.title}</td>
+                    <td className="px-3 py-2">{project.slug}</td>
+                    <td className="px-3 py-2">{project.vertical}</td>
+                    <td className="px-3 py-2 capitalize">{project.status}</td>
                     <td className="px-3 py-2">
                       <form action={toggleProjectFeatured}>
-                        <input type="hidden" name="id" value={p.id} />
-                        <Button size="sm" variant={p.featured ? "default" : "outline"}>{p.featured ? "Featured" : "Feature"}</Button>
+                        <input type="hidden" name="id" value={project.id} />
+                        <Button size="sm" variant={project.featured ? "default" : "outline"}>
+                          {project.featured ? "Featured" : "Feature"}
+                        </Button>
                       </form>
                     </td>
                     <td className="px-3 py-2">
-                      <Button size="sm" variant="outline" onClick={() => { setSelectedId(p.id); setOpen(true); }}>Edit</Button>
+                      <Button size="sm" variant="outline" onClick={() => handleOpen(project.id)}>
+                        Edit
+                      </Button>
                     </td>
                   </tr>
                 ))}
@@ -104,131 +134,125 @@ export function ProjectManager({ projects, status }: { projects: Project[]; stat
         </CardContent>
       </Card>
 
-      <Modal open={open} onClose={() => setOpen(false)} title={selected ? "Edit project" : "Add project"}>
+      <Modal open={open} onClose={handleClose} title={selected ? "Edit project" : "Add project"}>
         <form key={selected?.id ?? "create"} action={upsertProject} className={FORM_GRID}>
-            <input type="hidden" name="id" value={selected?.id ?? ""} />
-            <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium" htmlFor="title">
-                Title
-              </label>
-              <Input id="title" name="title" defaultValue={selected?.title ?? ""} required />
-            </div>
-            <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium" htmlFor="hero_image">Cover image</label>
-              <input id="hero_image" name="hero_image" type="file" accept="image/*" className="text-sm" />
-              {selected?.hero_url ? (
-                <p className="text-xs text-muted-foreground">Current: {selected.hero_url}</p>
-              ) : null}
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="slug">
-                Slug
-              </label>
-              <Input id="slug" name="slug" defaultValue={selected?.slug ?? ""} required />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="vertical">
-                Vertical
-              </label>
-              <select
-                id="vertical"
-                name="vertical"
-                defaultValue={selected?.vertical ?? "ai-security"}
-                className="border-input bg-background focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-offset-2"
+          <input type="hidden" name="id" value={selected?.id ?? ""} />
+          <div className="space-y-2 md:col-span-2">
+            <label className="text-sm font-medium" htmlFor="title">
+              Title
+            </label>
+            <Input id="title" name="title" defaultValue={selected?.title ?? ""} required />
+          </div>
+          <div className="space-y-2 md:col-span-2">
+            <label className="text-sm font-medium" htmlFor="hero_image">Cover image</label>
+            <input id="hero_image" name="hero_image" type="file" accept="image/*" className="text-sm" />
+            {selected?.hero_url ? (
+              <p className="text-xs text-muted-foreground">Current: {selected.hero_url}</p>
+            ) : null}
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="slug">
+              Slug
+            </label>
+            <Input id="slug" name="slug" defaultValue={selected?.slug ?? ""} required />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="vertical">
+              Vertical
+            </label>
+            <select
+              id="vertical"
+              name="vertical"
+              defaultValue={selected?.vertical ?? "ai-security"}
+              className="border-input bg-background focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-offset-2"
+            >
+              <option value="ai-security">AI Security</option>
+              <option value="secure-devops">Secure DevOps</option>
+              <option value="soc">SOC</option>
+            </select>
+          </div>
+          <div className="space-y-2 md:col-span-2">
+            <label className="text-sm font-medium" htmlFor="summary">
+              Summary
+            </label>
+            <Textarea id="summary" name="summary" defaultValue={selected?.summary ?? ""} rows={3} required />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="tags">
+              Tags (comma separated)
+            </label>
+            <Input id="tags" name="tags" defaultValue={selected ? selected.tags.join(", ") : ""} />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="tech_stack">
+              Tech stack (comma separated)
+            </label>
+            <Input id="tech_stack" name="tech_stack" defaultValue={selected ? selected.tech_stack.join(", ") : ""} />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="repo_url">
+              Repo URL
+            </label>
+            <Input id="repo_url" name="repo_url" defaultValue={selected?.repo_url ?? ""} />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="hero_url">
+              Hero image URL
+            </label>
+            <Input id="hero_url" name="hero_url" defaultValue={selected?.hero_url ?? ""} />
+          </div>
+          <div className="space-y-2 md:col-span-2">
+            <label className="text-sm font-medium" htmlFor="outcomes">
+              Outcomes (one per line: Metric|Value)
+            </label>
+            <Textarea id="outcomes" name="outcomes" defaultValue={formatOutcomes(selected ?? undefined)} rows={4} />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="status">
+              Status
+            </label>
+            <select
+              id="status"
+              name="status"
+              defaultValue={selected?.status ?? "draft"}
+              className="border-input bg-background focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-offset-2"
+            >
+              <option value="draft">Draft</option>
+              <option value="published">Published</option>
+            </select>
+          </div>
+          <div className="flex items-center gap-2">
+            <input id="featured" name="featured" type="checkbox" defaultChecked={selected?.featured ?? false} />
+            <label htmlFor="featured" className="text-sm font-medium">
+              Featured (max 6)
+            </label>
+          </div>
+          <div className="flex items-center justify-between gap-2 md:col-span-2">
+            {selected ? (
+              <form
+                action={deleteProject}
+                onSubmit={(event) => {
+                  if (!confirm("Delete this project?")) event.preventDefault();
+                }}
               >
-                <option value="ai-security">AI Security</option>
-                <option value="secure-devops">Secure DevOps</option>
-                <option value="soc">SOC</option>
-              </select>
-            </div>
-            <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium" htmlFor="summary">
-                Summary
-              </label>
-              <Textarea
-                id="summary"
-                name="summary"
-                defaultValue={selected?.summary ?? ""}
-                rows={3}
-                required
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="tags">
-                Tags (comma separated)
-              </label>
-              <Input
-                id="tags"
-                name="tags"
-                defaultValue={selected ? selected.tags.join(", ") : ""}
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="tech_stack">
-                Tech stack (comma separated)
-              </label>
-              <Input
-                id="tech_stack"
-                name="tech_stack"
-                defaultValue={selected ? selected.tech_stack.join(", ") : ""}
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="repo_url">
-                Repo URL
-              </label>
-              <Input id="repo_url" name="repo_url" defaultValue={selected?.repo_url ?? ""} />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="hero_url">
-                Hero image URL
-              </label>
-              <Input id="hero_url" name="hero_url" defaultValue={selected?.hero_url ?? ""} />
-            </div>
-            <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium" htmlFor="outcomes">
-                Outcomes (one per line: Metric|Value)
-              </label>
-              <Textarea
-                id="outcomes"
-                name="outcomes"
-                defaultValue={formatOutcomes(selected)}
-                rows={4}
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="status">
-                Status
-              </label>
-              <select
-                id="status"
-                name="status"
-                defaultValue={selected?.status ?? "draft"}
-                className="border-input bg-background focus:ring-ring w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-offset-2"
-              >
-                <option value="draft">Draft</option>
-                <option value="published">Published</option>
-              </select>
-            </div>
-            <div className="flex items-center gap-2">
-              <input id="featured" name="featured" type="checkbox" defaultChecked={selected?.featured ?? false} />
-              <label htmlFor="featured" className="text-sm font-medium">Featured (max 6)</label>
-            </div>
-            <div className="flex justify-end gap-2 md:col-span-2">
-              <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+                <input type="hidden" name="id" value={selected.id} />
+                <Button variant="destructive" type="submit">
+                  Delete project
+                </Button>
+              </form>
+            ) : (
+              <span />
+            )}
+            <div className="flex gap-2">
+              <Button type="button" variant="outline" onClick={handleClose}>
                 Cancel
               </Button>
-              <Button type="submit" onClick={() => setOpen(false)}>{selected ? "Save project" : "Create project"}</Button>
+              <Button type="submit">{selected ? "Save project" : "Create project"}</Button>
             </div>
-          </form>
-          {selected ? (
-            <form action={deleteProject} className="flex justify-between pt-3" onSubmit={(e) => { if (!confirm("Delete this project?")) e.preventDefault(); }}>
-              <input type="hidden" name="id" value={selected.id} />
-              <Button variant="destructive" type="submit">Delete project</Button>
-              <div />
-            </form>
-          ) : null}
+          </div>
+        </form>
       </Modal>
+
       <Card>
         <CardHeader>
           <CardTitle>Bulk import</CardTitle>
@@ -253,7 +277,7 @@ export function ProjectManager({ projects, status }: { projects: Project[]; stat
   );
 }
 
-function formatOutcomes(project: Project | undefined) {
+function formatOutcomes(project: Project | null | undefined) {
   if (!project?.outcomes) return "";
   return project.outcomes.map((outcome) => `${outcome.metric}|${outcome.value}`).join("\n");
 }

--- a/app/admin/(dashboard)/resumes/resume-manager.tsx
+++ b/app/admin/(dashboard)/resumes/resume-manager.tsx
@@ -144,32 +144,33 @@ export function ResumeManager({ resumes, status }: { resumes: Resume[]; status?:
                 <Button size="sm" variant="outline" type="submit">Save date</Button>
               </form>
             </div>
-            <div className="flex justify-end gap-2 md:col-span-2">
+            <div className="flex items-center justify-end gap-2 md:col-span-2">
               <Button type="button" variant="outline" onClick={() => { setSelectedId(""); setOpen(false); }}>
                 Cancel
               </Button>
-              <Button type="submit" onClick={() => setOpen(false)}>{selected ? "Save resume" : "Upload PDF & Save"}</Button>
+              <Button type="submit">{selected ? "Save resume" : "Upload PDF & Save"}</Button>
             </div>
           </form>
           {selected ? (
-            <form
-              action={deleteResume}
-              className="flex justify-between pt-3"
-              onSubmit={(e) => {
-                if (!confirm("Delete this resume? This cannot be undone.")) {
-                  e.preventDefault();
-                }
-              }}
-            >
-              <input type="hidden" name="id" value={selected.id} />
-              <div className="flex items-center gap-2">
-                <form action={toggleArchiveResume} onSubmit={(e) => { /* intentially no confirm for archive */ }}>
+            <div className="mt-3 flex items-center justify-between">
+              <div className="flex gap-2">
+                <form action={toggleArchiveResume}>
                   <input type="hidden" name="id" value={selected.id} />
                   <Button variant="outline" type="submit">{selected.archived ? "Restore" : "Archive"}</Button>
                 </form>
+                <form
+                  action={deleteResume}
+                  onSubmit={(e) => {
+                    if (!confirm("Delete this resume? This cannot be undone.")) {
+                      e.preventDefault();
+                    }
+                  }}
+                >
+                  <input type="hidden" name="id" value={selected.id} />
+                  <Button variant="destructive" type="submit">Delete resume</Button>
+                </form>
               </div>
-              <Button variant="destructive" type="submit">Delete resume</Button>
-            </form>
+            </div>
           ) : null}
       </Modal>
     </div>

--- a/app/admin/(dashboard)/social-posts/social-posts-manager.tsx
+++ b/app/admin/(dashboard)/social-posts/social-posts-manager.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 
+import { Modal } from "@/components/admin/modal";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -22,9 +23,33 @@ function toDatetimeLocal(iso: string) {
   return `${year}-${month}-${day}T${hours}:${minutes}`;
 }
 
+const FORM_GRID = "grid gap-3 md:grid-cols-2";
+
 export function SocialPostsManager({ posts, status }: { posts: SocialPost[]; status?: string }) {
   const [selectedId, setSelectedId] = useState<string>("");
-  const selected = useMemo(() => posts.find((post) => post.id === selectedId), [posts, selectedId]);
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+
+  const selected = useMemo(() => posts.find((post) => post.id === selectedId) ?? null, [posts, selectedId]);
+
+  const filtered = useMemo(() => {
+    const term = query.trim().toLowerCase();
+    if (!term) return posts;
+    return posts.filter((post) =>
+      [post.title, post.platform, post.summary ?? "", post.url]
+        .some((value) => value.toLowerCase().includes(term)),
+    );
+  }, [posts, query]);
+
+  const handleOpen = (id?: string) => {
+    setSelectedId(id ?? "");
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    setSelectedId("");
+  };
 
   return (
     <div className="space-y-6">
@@ -36,23 +61,16 @@ export function SocialPostsManager({ posts, status }: { posts: SocialPost[]; sta
               Manage the external signals that populate the feed and homepage highlights.
             </p>
           </div>
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-            <label className="text-sm font-medium" htmlFor="social-post-selector">
-              Select post
-            </label>
-            <select
-              id="social-post-selector"
-              value={selectedId}
-              onChange={(event) => setSelectedId(event.target.value)}
-              className="border-input bg-background focus:ring-ring w-64 rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-offset-2"
-            >
-              <option value="">Create new post…</option>
-              {posts.map((post) => (
-                <option key={post.id} value={post.id}>
-                  {post.title}
-                </option>
-              ))}
-            </select>
+          <div className="flex items-center gap-3">
+            <Input
+              placeholder="Search title, platform, url..."
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              className="w-64"
+            />
+            <Button size="sm" onClick={() => handleOpen()}>
+              Add post
+            </Button>
           </div>
         </div>
         {status === "success" ? (
@@ -64,97 +82,121 @@ export function SocialPostsManager({ posts, status }: { posts: SocialPost[]; sta
 
       <Card>
         <CardHeader>
-          <CardTitle>{selected ? "Edit post" : "Add post"}</CardTitle>
-          <CardDescription>Supports LinkedIn, GitHub, talks, or any public URL.</CardDescription>
+          <CardTitle>Posts</CardTitle>
+          <CardDescription>Filter by platform or title and edit posts inline.</CardDescription>
         </CardHeader>
-        <CardContent className="space-y-4">
-          <form
-            key={selected?.id ?? "create"}
-            action={upsertSocialPost}
-            className="grid gap-3 md:grid-cols-2"
-          >
-            <input type="hidden" name="id" value={selected?.id ?? ""} />
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="platform">
-                Platform
-              </label>
-              <Input id="platform" name="platform" defaultValue={selected?.platform ?? ""} list="platforms" required />
-              <datalist id="platforms">
-                <option value="GitHub" />
-                <option value="X" />
-                <option value="Twitter" />
-                <option value="LinkedIn" />
-                <option value="YouTube" />
-                <option value="Blog" />
-                <option value="Dev.to" />
-                <option value="Medium" />
-              </datalist>
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="title">
-                Title
-              </label>
-              <Input id="title" name="title" defaultValue={selected?.title ?? ""} required />
-            </div>
-            <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium" htmlFor="url">
-                URL
-              </label>
-              <Input id="url" name="url" defaultValue={selected?.url ?? ""} required />
-            </div>
-            <div className="space-y-2 md:col-span-2">
-              <label className="text-sm font-medium" htmlFor="summary">
-                Summary
-              </label>
-              <Textarea
-                id="summary"
-                name="summary"
-                defaultValue={selected?.summary ?? ""}
-                rows={3}
-              />
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium" htmlFor="posted_at">
-                Posted at
-              </label>
-              <Input
-                id="posted_at"
-                name="posted_at"
-                type="datetime-local"
-                defaultValue={selected ? toDatetimeLocal(selected.posted_at) : ""}
-                required
-              />
-            </div>
-            <div className="flex items-center gap-2">
-              <input
-                id="featured"
-                name="featured"
-                type="checkbox"
-                defaultChecked={selected?.featured ?? false}
-              />
-              <label className="text-sm font-medium" htmlFor="featured">
-                Featured
-              </label>
-            </div>
-            <div className="flex justify-end gap-2 md:col-span-2">
-              {selected ? (
-                <Button type="button" variant="outline" onClick={() => setSelectedId("")}>
-                  Clear selection
-                </Button>
-              ) : null}
-              <Button type="submit">{selected ? "Save post" : "Create post"}</Button>
-            </div>
-          </form>
-          {selected ? (
-            <form action={deleteSocialPost} className="flex justify-end">
-              <input type="hidden" name="id" value={selected.id} />
-              <Button variant="destructive" type="submit">
-                Delete post
-              </Button>
-            </form>
-          ) : null}
+        <CardContent>
+          <div className="max-h-[60vh] overflow-auto rounded-md border">
+            <table className="w-full text-left text-sm">
+              <thead className="sticky top-0 bg-muted/40">
+                <tr className="border-b">
+                  <th className="px-3 py-2">Title</th>
+                  <th className="px-3 py-2">Platform</th>
+                  <th className="px-3 py-2">Posted</th>
+                  <th className="px-3 py-2">Featured</th>
+                  <th className="px-3 py-2">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((post) => (
+                  <tr key={post.id} className="border-b last:border-0">
+                    <td className="px-3 py-2">{post.title}</td>
+                    <td className="px-3 py-2">{post.platform}</td>
+                    <td className="px-3 py-2 whitespace-nowrap">{new Date(post.posted_at).toLocaleString()}</td>
+                    <td className="px-3 py-2">{post.featured ? "Yes" : "No"}</td>
+                    <td className="px-3 py-2">
+                      <Button size="sm" variant="outline" onClick={() => handleOpen(post.id)}>
+                        Edit
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
         </CardContent>
       </Card>
+
+      <Modal open={open} onClose={handleClose} title={selected ? "Edit post" : "Add post"}>
+        <form key={selected?.id ?? "create"} action={upsertSocialPost} className={FORM_GRID}>
+          <input type="hidden" name="id" value={selected?.id ?? ""} />
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="platform">
+              Platform
+            </label>
+            <Input id="platform" name="platform" defaultValue={selected?.platform ?? ""} list="platforms" required />
+            <datalist id="platforms">
+              <option value="GitHub" />
+              <option value="X" />
+              <option value="Twitter" />
+              <option value="LinkedIn" />
+              <option value="YouTube" />
+              <option value="Blog" />
+              <option value="Dev.to" />
+              <option value="Medium" />
+            </datalist>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="title">
+              Title
+            </label>
+            <Input id="title" name="title" defaultValue={selected?.title ?? ""} required />
+          </div>
+          <div className="space-y-2 md:col-span-2">
+            <label className="text-sm font-medium" htmlFor="url">
+              URL
+            </label>
+            <Input id="url" name="url" defaultValue={selected?.url ?? ""} required />
+          </div>
+          <div className="space-y-2 md:col-span-2">
+            <label className="text-sm font-medium" htmlFor="summary">
+              Summary
+            </label>
+            <Textarea id="summary" name="summary" defaultValue={selected?.summary ?? ""} rows={3} />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="posted_at">
+              Posted at
+            </label>
+            <Input
+              id="posted_at"
+              name="posted_at"
+              type="datetime-local"
+              defaultValue={selected ? toDatetimeLocal(selected.posted_at) : ""}
+              required
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <input id="featured" name="featured" type="checkbox" defaultChecked={selected?.featured ?? false} />
+            <label className="text-sm font-medium" htmlFor="featured">
+              Featured (max 6)
+            </label>
+          </div>
+          <div className="flex items-center justify-between gap-2 md:col-span-2">
+            {selected ? (
+              <form
+                action={deleteSocialPost}
+                onSubmit={(event) => {
+                  if (!confirm("Delete this social post?")) event.preventDefault();
+                }}
+              >
+                <input type="hidden" name="id" value={selected.id} />
+                <Button variant="destructive" type="submit">
+                  Delete post
+                </Button>
+              </form>
+            ) : (
+              <span />
+            )}
+            <div className="flex gap-2">
+              <Button type="button" variant="outline" onClick={handleClose}>
+                Cancel
+              </Button>
+              <Button type="submit">{selected ? "Save post" : "Create post"}</Button>
+            </div>
+          </div>
+        </form>
+      </Modal>
     </div>
   );
 }

--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import { AspectRatio } from "@/components/ui/aspect-ratio";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { MDXServer } from "@/components/mdx/mdx-server";
-import type { ArticleDoc } from "@/.contentlayer/generated";
+import type { ArticleDoc } from "contentlayer/generated";
 import { findArticleDoc, getMdxSourceOrNull } from "@/lib/content/resolve";
 import { getArticleBySlug } from "@/lib/supabase/queries";
 

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -36,13 +36,17 @@ export default async function ArticlesPage() {
                     <h2 className="text-2xl font-semibold tracking-tight group-hover:underline">
                       {article.title}
                     </h2>
-                    {article.featured ? <Badge className="mt-1">Featured</Badge> : null}
                     {article.summary ? (
                       <p className="text-muted-foreground mt-2 text-base line-clamp-3">{article.summary}</p>
                     ) : null}
-                    {article.tags?.length ? (
+                    {(article.featured || (article.tags?.length ?? 0) > 0) ? (
                       <div className="mt-3 flex flex-wrap gap-2">
-                        {article.tags.map((tag) => (
+                        {article.featured ? (
+                          <Badge variant="secondary" className="font-medium uppercase">
+                            Featured
+                          </Badge>
+                        ) : null}
+                        {article.tags?.map((tag) => (
                           <Badge key={tag} variant="secondary">
                             {tag}
                           </Badge>

--- a/app/case-studies/[slug]/page.tsx
+++ b/app/case-studies/[slug]/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 
 import { Badge } from "@/components/ui/badge";
-import type { CaseStudyDoc } from "@/.contentlayer/generated";
+import type { CaseStudyDoc } from "contentlayer/generated";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { MDXServer } from "@/components/mdx/mdx-server";
 import { findCaseStudyDoc, getMdxSourceOrNull } from "@/lib/content/resolve";

--- a/app/case-studies/page.tsx
+++ b/app/case-studies/page.tsx
@@ -36,11 +36,15 @@ export default async function CaseStudiesPage() {
                 <CardTitle className="text-xl">
                   <span className="group-hover:underline">{study.title}</span>
                 </CardTitle>
-                {study.featured ? <div><Badge>Featured</Badge></div> : null}
                 <CardDescription>{study.summary}</CardDescription>
               </CardHeader>
               <CardContent className="mt-auto space-y-3 text-sm">
                 <div className="flex flex-wrap gap-2">
+                  {study.featured ? (
+                    <Badge variant="secondary" className="font-medium uppercase">
+                      Featured
+                    </Badge>
+                  ) : null}
                   {study.tags.map((tag) => (
                     <Badge key={tag} variant="secondary">
                       {tag}

--- a/app/legal/privacy/page.tsx
+++ b/app/legal/privacy/page.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { MDXServer } from "@/components/mdx/mdx-server";
-import type { LegalDoc } from "@/.contentlayer/generated";
+import type { LegalDoc } from "contentlayer/generated";
 import { findArticleDoc, getMdxSourceOrNull } from "@/lib/content/resolve";
 
 export default async function PrivacyPage() {

--- a/app/legal/security/page.tsx
+++ b/app/legal/security/page.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { MDXServer } from "@/components/mdx/mdx-server";
-import type { LegalDoc } from "@/.contentlayer/generated";
+import type { LegalDoc } from "contentlayer/generated";
 import { findArticleDoc, getMdxSourceOrNull } from "@/lib/content/resolve";
 
 export default async function SecurityPage() {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -298,16 +298,24 @@ export default async function HomePage() {
                 <Card key={post.id} className="group relative">
                   <Link href={post.url} target="_blank" rel="noreferrer" className="absolute inset-0" aria-label={post.title} />
                   <CardHeader>
-                    <div className="flex items-center justify-between gap-3">
-                      <CardTitle className="text-base group-hover:underline">{post.title}</CardTitle>
-                      <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
-                        <span>{new Date(post.posted_at).toLocaleDateString()}</span>
-                        <span aria-hidden className="ml-1 inline-flex h-8 w-8 items-center justify-center rounded-full" style={{ backgroundColor: `#${icon.hex}` }} title={post.platform}>
-                          <svg viewBox="0 0 24 24" width="18" height="18" fill="white" xmlns="http://www.w3.org/2000/svg">
-                            <path d={icon.path} />
-                          </svg>
-                        </span>
-                      </div>
+                    <CardTitle className="text-base group-hover:underline">{post.title}</CardTitle>
+                    <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+                      <span>{new Date(post.posted_at).toLocaleDateString()}</span>
+                      {post.featured ? (
+                        <Badge variant="secondary" className="font-medium uppercase">
+                          Featured
+                        </Badge>
+                      ) : null}
+                      <span
+                        aria-hidden
+                        className="inline-flex h-8 w-8 items-center justify-center rounded-full"
+                        style={{ backgroundColor: `#${icon.hex}` }}
+                        title={post.platform}
+                      >
+                        <svg viewBox="0 0 24 24" width="18" height="18" fill="white" xmlns="http://www.w3.org/2000/svg">
+                          <path d={icon.path} />
+                        </svg>
+                      </span>
                     </div>
                   </CardHeader>
                   <CardContent className="space-y-3 text-sm">

--- a/app/portfolio/page.tsx
+++ b/app/portfolio/page.tsx
@@ -91,11 +91,15 @@ export default async function PortfolioPage() {
                   </div>
                   <CardHeader>
                     <CardTitle className="text-xl group-hover:underline">{project.title}</CardTitle>
-                    {project.featured ? <div><Badge>Featured</Badge></div> : null}
                     <CardDescription>{project.summary}</CardDescription>
                   </CardHeader>
                   <CardContent className="mt-auto space-y-3 text-sm">
                     <div className="flex flex-wrap gap-2">
+                      {project.featured ? (
+                        <Badge variant="secondary" className="font-medium uppercase">
+                          Featured
+                        </Badge>
+                      ) : null}
                       {project.tech_stack.map((tool) => (
                         <Badge key={tool} variant="secondary">
                           {tool}

--- a/app/social-feed/page.tsx
+++ b/app/social-feed/page.tsx
@@ -35,10 +35,16 @@ export default async function SocialFeedPage() {
             return (
               <Card key={post.id}>
                 <CardHeader>
-                  <div className="flex items-center justify-between gap-3">
+                  <CardTitle className="text-lg">{post.title}</CardTitle>
+                  <CardDescription className="text-sm">{post.platform}</CardDescription>
+                  <div className="flex items-center gap-3 text-sm text-muted-foreground">
                     <div className="flex items-center gap-2">
-                      {post.featured ? <Badge variant="default">Featured</Badge> : null}
-                      <CardTitle className="text-lg">{post.title}</CardTitle>
+                      <span>{new Date(post.posted_at).toLocaleDateString()}</span>
+                      {post.featured ? (
+                        <Badge variant="secondary" className="font-medium uppercase">
+                          Featured
+                        </Badge>
+                      ) : null}
                     </div>
                     <span
                       aria-hidden
@@ -51,11 +57,6 @@ export default async function SocialFeedPage() {
                       </svg>
                     </span>
                   </div>
-                  <CardDescription className="space-x-2 text-sm">
-                    <span>{post.platform}</span>
-                    <span>•</span>
-                    <span>{new Date(post.posted_at).toLocaleDateString()}</span>
-                  </CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-3 text-sm">
                   {post.summary ? <p className="text-muted-foreground">{post.summary}</p> : null}

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -72,11 +72,12 @@ export default makeSource({
   contentDirPath: "content",
   documentTypes: [ArticleDoc, CaseStudyDoc, LegalDoc],
   mdx: {
-    rehypePlugins: ([
+    rehypePlugins: [
       rehypeSlug,
       [rehypeAutolinkHeadings, { behavior: "wrap" }],
+      // @ts-ignore Pretty code plugin uses older unified typings
       [rehypePrettyCode, { theme: "github-dark" }],
-    ] as any),
+    ],
   },
   disableImportAliasWarning: true,
 });

--- a/lib/content/resolve.ts
+++ b/lib/content/resolve.ts
@@ -1,5 +1,5 @@
-import type { ArticleDoc, CaseStudyDoc, LegalDoc } from "@/.contentlayer/generated";
-import { allArticleDocs, allCaseStudyDocs, allLegalDocs } from "@/.contentlayer/generated";
+import type { ArticleDoc, CaseStudyDoc, LegalDoc } from "contentlayer/generated";
+import { allArticleDocs, allCaseStudyDocs, allLegalDocs } from "contentlayer/generated";
 import { getMdxByKey } from "@/lib/supabase/queries";
 
 const toContentKey = (bodyPath: string) => bodyPath.replace(/^\//, "");

--- a/tests/import-keyvalue.test.ts
+++ b/tests/import-keyvalue.test.ts
@@ -28,6 +28,6 @@ describe("serializeKeyValueLines", () => {
 
     test("empty returns empty string", () => {
         expect(serializeKeyValueLines([])).toBe("");
-        expect(serializeKeyValueLines(null as unknown as any)).toBe("");
+        expect(serializeKeyValueLines(null)).toBe("");
     });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "contentlayer/generated": ["./.contentlayer/generated"]
     },
     "baseUrl": "."
   },


### PR DESCRIPTION
## Summary
- align featured badges with tag groups across portfolio, case study, article, and social feed pages while updating the home feed layout
- rebuild projects, case studies, contact methods, social posts, and resumes admin screens to use searchable tables with modal forms and improved action alignment
- adjust Contentlayer configuration and TypeScript paths to support the new imports

## Testing
- pnpm lint
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d1656877f883258ce46b8f9e55e8d2