### PR TITLE
feat: improve admin relations and profile fields

### DIFF
--- a/.docs/SUPABASE_INIT.sql
+++ b/.docs/SUPABASE_INIT.sql
@@ -226,6 +226,10 @@ alter table public.site_profile add column if not exists interests jsonb default
 alter table public.site_profile add column if not exists speaking jsonb default '[]';
 alter table public.site_profile add column if not exists certifications jsonb default '[]';
 alter table public.site_profile add column if not exists awards jsonb default '[]';
+alter table public.site_profile add column if not exists pronouns text;
+alter table public.site_profile add column if not exists phonetic_name text;
+alter table public.site_profile add column if not exists languages jsonb default '[]';
+alter table public.site_profile add column if not exists access_notes text;
 
 -- Relationship tables for explicit related content ------------------
 create table if not exists public.article_related_projects (

--- a/.docs/SUPABASE_SEED.sql
+++ b/.docs/SUPABASE_SEED.sql
@@ -295,7 +295,27 @@ on conflict (id) do update set
   updated_at = now();
 
 -- Site profile ---------------------------------------------------------------
-insert into public.site_profile (id, full_name, headline, subheadline, summary, avatar_url, location, hiring_status, resume_preference, highlights, hobbies, interests)
+insert into public.site_profile (
+  id,
+  full_name,
+  headline,
+  subheadline,
+  summary,
+  avatar_url,
+  location,
+  hiring_status,
+  resume_preference,
+  highlights,
+  hobbies,
+  interests,
+  speaking,
+  certifications,
+  awards,
+  pronouns,
+  phonetic_name,
+  languages,
+  access_notes
+)
 values (
   '22222222-2222-2222-2222-222222222222',
   'Jeff Weber',
@@ -308,7 +328,14 @@ values (
   'ai-security',
   '[{"label":"7.3x reduction in AI risk remediation","value":"Fortune 100 fintech"},{"label":"0 critical audit findings","value":"After secure DevOps transformation"},{"label":"2.4x analyst throughput","value":"SOC automation program"}]'::jsonb,
   '["Cycling","Climbing","Maker projects"]'::jsonb,
-  '["AI safety","Developer experience","Cloud governance"]'::jsonb
+  '["AI safety","Developer experience","Cloud governance"]'::jsonb,
+  '["BSides SF 2024 keynote","OWASP AppSec 2023"]'::jsonb,
+  '["CISSP","OSCP"]'::jsonb,
+  '["DEF CON CTF finalist","Supabase Launch Week award"]'::jsonb,
+  'he/him',
+  'JEFF WEE-bur',
+  '["English (native)","Spanish (conversational)"]'::jsonb,
+  'Happy to accommodate ASL interpreters and flexible meeting hours across time zones.'
 )
 on conflict (id) do update set
   full_name = excluded.full_name,
@@ -322,6 +349,13 @@ on conflict (id) do update set
   highlights = excluded.highlights,
   hobbies = excluded.hobbies,
   interests = excluded.interests,
+  speaking = excluded.speaking,
+  certifications = excluded.certifications,
+  awards = excluded.awards,
+  pronouns = excluded.pronouns,
+  phonetic_name = excluded.phonetic_name,
+  languages = excluded.languages,
+  access_notes = excluded.access_notes,
   updated_at = now();
 
 -- Contact links --------------------------------------------------------------

--- a/app/admin/(dashboard)/case-studies/page.tsx
+++ b/app/admin/(dashboard)/case-studies/page.tsx
@@ -3,6 +3,7 @@ import {
   fetchAllCaseStudies,
   fetchAllMdxDocuments,
   fetchAllProjects,
+  fetchArticleIdsByCaseStudy,
   fetchProjectIdsByCaseStudy,
 } from "@/lib/admin/queries";
 import { toContentKey } from "@/lib/content/resolve";
@@ -15,13 +16,15 @@ export default async function CaseStudiesAdminPage({
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const sp = await searchParams;
-  const [caseStudies, articles, availableDocs, projects, rel] = await Promise.all([
-    fetchAllCaseStudies(),
-    fetchAllArticles(),
-    fetchAllMdxDocuments(),
-    fetchAllProjects(),
-    fetchProjectIdsByCaseStudy(),
-  ]);
+  const [caseStudies, articles, availableDocs, projects, projectMap, articleMap] =
+    await Promise.all([
+      fetchAllCaseStudies(),
+      fetchAllArticles(),
+      fetchAllMdxDocuments(),
+      fetchAllProjects(),
+      fetchProjectIdsByCaseStudy(),
+      fetchArticleIdsByCaseStudy(),
+    ]);
   const status = typeof sp?.status === "string" ? sp.status : undefined;
   const used = new Set<string>([
     ...caseStudies.map((s) => toContentKey(s.body_path ?? "")),
@@ -34,7 +37,8 @@ export default async function CaseStudiesAdminPage({
       usedKeys={[...used]}
       projects={projects}
       articles={articles}
-      relatedProjectIdsByCaseStudy={rel}
+      relatedProjectIdsByCaseStudy={projectMap}
+      relatedArticleIdsByCaseStudy={articleMap}
       status={status}
     />
   );

--- a/app/admin/(dashboard)/contact-links/contact-links-manager.tsx
+++ b/app/admin/(dashboard)/contact-links/contact-links-manager.tsx
@@ -161,17 +161,9 @@ export function ContactLinksManager({ links, status }: { links: ContactLink[]; s
               defaultValue={selected?.order_index ?? links.length}
             />
           </div>
-          <div className="flex items-center justify-end gap-2 pt-2 md:col-span-2">
-            <Button type="button" variant="outline" onClick={handleClose}>
-              Cancel
-            </Button>
-            <Button type="submit" form="contact-link-form">
-              {selected ? "Save" : "Create"}
-            </Button>
-          </div>
         </form>
-        {selected ? (
-          <div className="flex items-center justify-between pt-3">
+        <div className="flex items-center justify-between gap-2 pt-3">
+          {selected ? (
             <form
               action={deleteContactLink}
               onSubmit={(event) => {
@@ -184,9 +176,18 @@ export function ContactLinksManager({ links, status }: { links: ContactLink[]; s
                 Delete
               </Button>
             </form>
+          ) : (
             <span />
+          )}
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button type="submit" form="contact-link-form">
+              {selected ? "Save" : "Create"}
+            </Button>
           </div>
-        ) : null}
+        </div>
       </Modal>
     </div>
   );

--- a/app/admin/(dashboard)/projects/page.tsx
+++ b/app/admin/(dashboard)/projects/page.tsx
@@ -3,6 +3,7 @@ import {
   fetchAllCaseStudies,
   fetchCaseStudyIdsByProject,
   fetchAllArticles,
+  fetchArticleIdsByProject,
 } from "@/lib/admin/queries";
 
 import { ProjectManager } from "./project-manager";
@@ -13,11 +14,12 @@ export default async function ProjectsAdminPage({
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const sp = await searchParams;
-  const [projects, caseStudies, rel, articles] = await Promise.all([
+  const [projects, caseStudies, rel, articles, articleRel] = await Promise.all([
     fetchAllProjects(),
     fetchAllCaseStudies(),
     fetchCaseStudyIdsByProject(),
     fetchAllArticles(),
+    fetchArticleIdsByProject(),
   ]);
   const status = typeof sp?.status === "string" ? sp.status : undefined;
 
@@ -27,6 +29,7 @@ export default async function ProjectsAdminPage({
       caseStudies={caseStudies}
       relatedCaseStudyIdsByProject={rel}
       articles={articles}
+      relatedArticleIdsByProject={articleRel}
       status={status}
     />
   );

--- a/app/admin/(dashboard)/projects/project-manager.tsx
+++ b/app/admin/(dashboard)/projects/project-manager.tsx
@@ -2,12 +2,13 @@
 
 import { useMemo, useState } from "react";
 
+import { RelatedChecklist } from "@/app/admin/_components/related-checklist";
+import { Modal } from "@/components/admin/modal";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import type { Project, CaseStudy } from "@/lib/supabase/types";
-import { Modal } from "@/components/admin/modal";
+import type { Article, CaseStudy, Project } from "@/lib/supabase/types";
 
 import { deleteProject, importProjects, toggleProjectFeatured, upsertProject } from "./actions";
 
@@ -18,12 +19,16 @@ type SortDirection = "asc" | "desc";
 export function ProjectManager({
   projects,
   caseStudies,
+  articles,
   relatedCaseStudyIdsByProject,
+  relatedArticleIdsByProject,
   status,
 }: {
   projects: Project[];
   caseStudies: CaseStudy[];
+  articles: Article[];
   relatedCaseStudyIdsByProject: Record<string, string[]>;
+  relatedArticleIdsByProject: Record<string, string[]>;
   status?: string;
 }) {
   const [selectedId, setSelectedId] = useState<string>("");
@@ -106,6 +111,11 @@ export function ProjectManager({
     setOpen(false);
     setSelectedId("");
   };
+
+  const selectedCaseStudyIds = selected?.id
+    ? (relatedCaseStudyIdsByProject[selected.id] ?? [])
+    : [];
+  const selectedArticleIds = selected?.id ? (relatedArticleIdsByProject[selected.id] ?? []) : [];
 
   return (
     <div className="space-y-6">
@@ -348,16 +358,22 @@ export function ProjectManager({
             <label className="text-sm font-medium">Related case studies</label>
             <RelatedChecklist
               name="related_case_study_ids"
-              items={caseStudies.map((s) => ({ id: s.id, label: `${s.title} (${s.slug})` }))}
-              selected={(selected?.id && relatedCaseStudyIdsByProject[selected.id]) || []}
+              items={caseStudies.map((study) => ({
+                id: study.id,
+                label: `${study.title} (${study.slug})`,
+              }))}
+              selected={selectedCaseStudyIds}
             />
           </div>
           <div className="space-y-2 md:col-span-2">
             <label className="text-sm font-medium">Related articles</label>
             <RelatedChecklist
               name="related_article_ids"
-              items={articles.map((a) => ({ id: a.id, label: `${a.title} (${a.slug})` }))}
-              selected={[]}
+              items={articles.map((article) => ({
+                id: article.id,
+                label: `${article.title} (${article.slug})`,
+              }))}
+              selected={selectedArticleIds}
             />
           </div>
           <div className="space-y-2">
@@ -385,17 +401,9 @@ export function ProjectManager({
               Featured (max 6)
             </label>
           </div>
-          <div className="flex items-center justify-end gap-2 pt-2 md:col-span-2">
-            <Button type="button" variant="outline" onClick={handleClose}>
-              Cancel
-            </Button>
-            <Button type="submit" form="project-form">
-              {selected ? "Save project" : "Create project"}
-            </Button>
-          </div>
         </form>
-        {selected ? (
-          <div className="flex items-center justify-between pt-3">
+        <div className="flex items-center justify-between gap-2 pt-3">
+          {selected ? (
             <form
               action={deleteProject}
               onSubmit={(event) => {
@@ -408,9 +416,18 @@ export function ProjectManager({
                 Delete project
               </Button>
             </form>
+          ) : (
             <span />
+          )}
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button type="submit" form="project-form">
+              {selected ? "Save project" : "Create project"}
+            </Button>
           </div>
-        ) : null}
+        </div>
       </Modal>
 
       <Card>
@@ -442,53 +459,4 @@ export function ProjectManager({
 function formatOutcomes(project: Project | null | undefined) {
   if (!project?.outcomes) return "";
   return project.outcomes.map((outcome) => `${outcome.metric}|${outcome.value}`).join("\n");
-}
-
-function RelatedChecklist({
-  name,
-  items,
-  selected,
-}: {
-  name: string;
-  items: Array<{ id: string; label: string }>;
-  selected: string[];
-}) {
-  const [query, setQuery] = useState("");
-  const [chosen, setChosen] = useState<string[]>(selected);
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    return q ? items.filter((i) => i.label.toLowerCase().includes(q)) : items;
-  }, [items, query]);
-  const toggle = (id: string) =>
-    setChosen((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
-  return (
-    <div className="rounded-md border">
-      <div className="flex items-center gap-2 border-b p-2">
-        <Input placeholder="Search..." value={query} onChange={(e) => setQuery(e.target.value)} />
-        {chosen.map((id) => (
-          <input key={id} type="hidden" name={name} value={id} />
-        ))}
-      </div>
-      <div className="max-h-48 overflow-auto p-2 text-sm">
-        <table className="w-full">
-          <tbody>
-            {filtered.map((i) => (
-              <tr key={i.id}>
-                <td className="py-1">
-                  <label className="inline-flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      checked={chosen.includes(i.id)}
-                      onChange={() => toggle(i.id)}
-                    />
-                    {i.label}
-                  </label>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  );
 }

--- a/app/admin/(dashboard)/site-profile/actions.ts
+++ b/app/admin/(dashboard)/site-profile/actions.ts
@@ -22,6 +22,10 @@ const profileSchema = z.object({
   speaking: z.string().optional(),
   certifications: z.string().optional(),
   awards: z.string().optional(),
+  pronouns: z.string().optional(),
+  phonetic_name: z.string().optional(),
+  languages: z.string().optional(),
+  access_notes: z.string().optional(),
 });
 
 export async function upsertSiteProfile(formData: FormData) {
@@ -45,6 +49,10 @@ export async function upsertSiteProfile(formData: FormData) {
     speaking: formData.get("speaking")?.toString() ?? "",
     certifications: formData.get("certifications")?.toString() ?? "",
     awards: formData.get("awards")?.toString() ?? "",
+    pronouns: formData.get("pronouns")?.toString() ?? "",
+    phonetic_name: formData.get("phonetic_name")?.toString() ?? "",
+    languages: formData.get("languages")?.toString() ?? "",
+    access_notes: formData.get("access_notes")?.toString() ?? "",
   });
 
   const admin = createSupabaseAdminClient();
@@ -54,6 +62,11 @@ export async function upsertSiteProfile(formData: FormData) {
       .split(/\r?\n/)
       .map((l) => l.trim())
       .filter(Boolean);
+
+  const cleanText = (value: string | undefined) => {
+    const trimmed = (value ?? "").trim();
+    return trimmed.length > 0 ? trimmed : null;
+  };
 
   const { error } = await admin.from("site_profile").upsert({
     id: payload.id,
@@ -70,6 +83,10 @@ export async function upsertSiteProfile(formData: FormData) {
     speaking: toLines(payload.speaking ?? ""),
     certifications: toLines(payload.certifications ?? ""),
     awards: toLines(payload.awards ?? ""),
+    pronouns: cleanText(payload.pronouns),
+    phonetic_name: cleanText(payload.phonetic_name),
+    languages: toLines(payload.languages ?? ""),
+    access_notes: cleanText(payload.access_notes),
   });
 
   if (error) {

--- a/app/admin/(dashboard)/site-profile/page.tsx
+++ b/app/admin/(dashboard)/site-profile/page.tsx
@@ -36,6 +36,11 @@ export default async function SiteProfileAdminPage({
           </CardHeader>
           <CardContent className="space-y-4 text-sm">
             <Badge variant="outline">{profile?.hiring_status ?? "Open to opportunities"}</Badge>
+            {profile?.pronouns ? (
+              <Badge variant="secondary" className="uppercase tracking-wide">
+                {profile.pronouns}
+              </Badge>
+            ) : null}
             <div>
               <p className="text-lg font-semibold">
                 {profile?.headline ?? "Security-first engineering leader."}
@@ -44,6 +49,9 @@ export default async function SiteProfileAdminPage({
                 {profile?.summary ?? "Add a summary to describe your focus."}
               </p>
             </div>
+            {profile?.phonetic_name ? (
+              <p className="text-muted-foreground text-xs">Pronounced: {profile.phonetic_name}</p>
+            ) : null}
             {/* Highlights removed from profile; hero metrics now derive from featured case studies. */}
             {profile?.avatar_url ? (
               <div className="relative mt-4 h-32 w-32 overflow-hidden rounded-full border">
@@ -77,6 +85,30 @@ export default async function SiteProfileAdminPage({
                   defaultValue={profile?.full_name ?? ""}
                   required
                 />
+              </div>
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <label className="text-sm font-medium" htmlFor="pronouns">
+                    Pronouns
+                  </label>
+                  <Input
+                    id="pronouns"
+                    name="pronouns"
+                    defaultValue={profile?.pronouns ?? ""}
+                    placeholder="they/them"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium" htmlFor="phonetic_name">
+                    Name pronunciation
+                  </label>
+                  <Input
+                    id="phonetic_name"
+                    name="phonetic_name"
+                    defaultValue={profile?.phonetic_name ?? ""}
+                    placeholder="JEFF WEE-bur"
+                  />
+                </div>
               </div>
               <div className="space-y-2">
                 <label className="text-sm font-medium" htmlFor="headline">
@@ -219,6 +251,33 @@ export default async function SiteProfileAdminPage({
                     defaultValue={(profile?.interests ?? []).join("\n")}
                     rows={5}
                   />
+                </div>
+              </div>
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-2">
+                  <label className="text-sm font-medium" htmlFor="languages">
+                    Languages (one per line)
+                  </label>
+                  <Textarea
+                    id="languages"
+                    name="languages"
+                    defaultValue={(profile?.languages ?? []).join("\n")}
+                    rows={4}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium" htmlFor="access_notes">
+                    Collaboration & access notes
+                  </label>
+                  <Textarea
+                    id="access_notes"
+                    name="access_notes"
+                    defaultValue={profile?.access_notes ?? ""}
+                    rows={4}
+                  />
+                  <p className="text-muted-foreground text-xs">
+                    Optional: share accessibility preferences, scheduling needs, or accommodations.
+                  </p>
                 </div>
               </div>
               {saved ? <p className="text-sm text-emerald-600">Profile saved.</p> : null}

--- a/app/admin/_components/related-checklist.tsx
+++ b/app/admin/_components/related-checklist.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { Input } from "@/components/ui/input";
+
+export type RelatedChecklistItem = {
+  id: string;
+  label: string;
+};
+
+export function RelatedChecklist({
+  name,
+  items,
+  selected = [],
+  emptyLabel = "No items available",
+}: {
+  name: string;
+  items: RelatedChecklistItem[];
+  selected?: string[];
+  emptyLabel?: string;
+}) {
+  const [query, setQuery] = useState("");
+  const [chosen, setChosen] = useState<string[]>(selected);
+
+  useEffect(() => {
+    setChosen(selected);
+  }, [selected]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter((item) => item.label.toLowerCase().includes(q));
+  }, [items, query]);
+
+  const toggle = (id: string) => {
+    setChosen((prev) => (prev.includes(id) ? prev.filter((value) => value !== id) : [...prev, id]));
+  };
+
+  return (
+    <div className="rounded-md border">
+      <div className="flex items-center gap-2 border-b p-2">
+        <Input
+          placeholder="Search..."
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+        />
+        {chosen.map((id) => (
+          <input key={id} type="hidden" name={name} value={id} />
+        ))}
+      </div>
+      <div className="max-h-48 overflow-auto p-2 text-sm">
+        {filtered.length === 0 ? (
+          <p className="text-muted-foreground text-xs">{emptyLabel}</p>
+        ) : (
+          <table className="w-full">
+            <tbody>
+              {filtered.map((item) => (
+                <tr key={item.id}>
+                  <td className="py-1">
+                    <label className="inline-flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        checked={chosen.includes(item.id)}
+                        onChange={() => toggle(item.id)}
+                      />
+                      {item.label}
+                    </label>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/articles/[slug]/page.tsx
+++ b/app/articles/[slug]/page.tsx
@@ -1,8 +1,8 @@
+import Image from "next/image";
 import { notFound } from "next/navigation";
 
-import { Badge } from "@/components/ui/badge";
-import Image from "next/image";
 import { AspectRatio } from "@/components/ui/aspect-ratio";
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { MDXServer } from "@/components/mdx/mdx-server";
 import type { ArticleDoc } from "contentlayer/generated";
@@ -12,71 +12,25 @@ import {
   getPublishedArticles,
   getPublishedCaseStudies,
   getPublishedProjects,
+  getRelatedCaseStudiesForArticle,
+  getRelatedProjectsForArticle,
 } from "@/lib/supabase/queries";
 
 export default async function ArticlePage({ params }: { params: Promise<{ slug: string }> }) {
-  export default async function ArticlePage({ params }: { params: Promise<{ slug: string }> }) {
-    const p = await params;
-    const article = await getArticleBySlug(p.slug);
+  const p = await params;
+  const article = await getArticleBySlug(p.slug);
 
-    if (!article) {
-      notFound();
-    }
+  if (!article) {
+    notFound();
+  }
 
-    const doc = findArticleDoc(article.body_path ?? "");
-    const supabaseMdx = doc ? null : await getMdxSourceOrNull(article.body_path ?? "");
-    const [relatedProjects, relatedCaseStudies] = await Promise.all([
-      getRelatedProjectsForArticle(article.id),
-      getRelatedCaseStudiesForArticle(article.id),
-    ]);
+  const doc = findArticleDoc(article.body_path ?? "");
+  const supabaseMdx = doc ? null : await getMdxSourceOrNull(article.body_path ?? "");
 
-    if (!doc && !supabaseMdx) {
-      return (
-        <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-4 py-12 sm:px-6 sm:py-16">
-          <header className="space-y-4">
-            <div className="flex flex-wrap gap-2">
-              {article.tags.map((tag) => (
-                <Badge key={tag} variant="outline">
-                  {tag}
-                </Badge>
-              ))}
-            </div>
-            <div className="space-y-2">
-              <h1 className="text-4xl font-semibold tracking-tight">{article.title}</h1>
-              {article.summary ? (
-                <p className="text-muted-foreground text-lg">{article.summary}</p>
-              ) : null}
-            </div>
-          </header>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Content missing</CardTitle>
-              <CardDescription>
-                Provide an MDX document at <code>{article.body_path}</code> to render the full
-                article.
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="text-muted-foreground text-sm">
-              The metadata already lives in Supabase—add the MDX file to `content/` and redeploy.
-            </CardContent>
-          </Card>
-        </div>
-      );
-    }
-
+  if (!doc && !supabaseMdx) {
     return (
       <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-4 py-12 sm:px-6 sm:py-16">
         <header className="space-y-4">
-          <AspectRatio ratio={16 / 9}>
-            <Image
-              src={article.hero_url || "/default-card.svg"}
-              alt=""
-              fill
-              sizes="100vw"
-              className="rounded-md object-cover"
-            />
-          </AspectRatio>
           <div className="flex flex-wrap gap-2">
             {article.tags.map((tag) => (
               <Badge key={tag} variant="outline">
@@ -87,118 +41,180 @@ export default async function ArticlePage({ params }: { params: Promise<{ slug: 
           <div className="space-y-2">
             <h1 className="text-4xl font-semibold tracking-tight">{article.title}</h1>
             {article.summary ? (
-              <Card className="border-primary/30 bg-primary/5">
-                <CardHeader>
-                  <CardTitle className="text-base">TL;DR</CardTitle>
-                  <CardDescription className="text-foreground text-sm">
-                    {article.summary}
-                  </CardDescription>
-                </CardHeader>
-              </Card>
+              <p className="text-muted-foreground text-lg">{article.summary}</p>
             ) : null}
           </div>
         </header>
-        {doc ? (
-          <MDXServer source={(doc as ArticleDoc).body.raw ?? ""} />
-        ) : (
-          <MDXServer source={supabaseMdx ?? ""} />
-        )}
-        {/* Related content */}
-        <RelatedContent currentSlug={article.slug} currentTags={article.tags} />
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Content missing</CardTitle>
+            <CardDescription>
+              Provide an MDX document at <code>{article.body_path}</code> to render the full
+              article.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="text-muted-foreground text-sm">
+            The metadata already lives in Supabase—add the MDX file to `content/` and redeploy.
+          </CardContent>
+        </Card>
       </div>
     );
   }
 
-  async function RelatedContent({
-    currentSlug,
-    currentTags,
-  }: {
-    currentSlug: string;
-    currentTags: string[];
-  }) {
-    const [projects, studies, articles] = await Promise.all([
-      getPublishedProjects(),
-      getPublishedCaseStudies(),
-      getPublishedArticles(),
-    ]);
-    const hasOverlap = (tags: string[]) => tags.some((t) => currentTags.includes(t));
-    const relatedProjects = projects.filter((p) => hasOverlap(p.tags)).slice(0, 3);
-    const relatedStudies = studies.filter((s) => hasOverlap(s.tags)).slice(0, 3);
-    const relatedArticles = articles
-      .filter((a) => a.slug !== currentSlug && hasOverlap(a.tags))
-      .slice(0, 3);
-
-    if (relatedProjects.length + relatedStudies.length + relatedArticles.length === 0) return null;
-
-    return (
-      <section className="space-y-6">
-        <h2 className="text-2xl font-semibold">Related</h2>
-        <div className="grid gap-4">
-          {relatedProjects.length ? (
-            <div>
-              <h3 className="text-muted-foreground mb-2 text-sm font-medium uppercase">Projects</h3>
-              <div className="grid gap-4 md:grid-cols-2">
-                {relatedProjects.map((project) => (
-                  <Card key={project.id} className="group relative">
-                    <a
-                      href={`/portfolio/${project.slug}`}
-                      className="absolute inset-0"
-                      aria-label={project.title}
-                    />
-                    <CardHeader>
-                      <CardTitle className="text-base group-hover:underline">
-                        {project.title}
-                      </CardTitle>
-                      <CardDescription>{project.summary}</CardDescription>
-                    </CardHeader>
-                  </Card>
-                ))}
-              </div>
-            </div>
-          ) : null}
-          {relatedStudies.length ? (
-            <div>
-              <h3 className="text-muted-foreground mb-2 text-sm font-medium uppercase">
-                Case studies
-              </h3>
-              <div className="grid gap-4 md:grid-cols-2">
-                {relatedStudies.map((study) => (
-                  <Card key={study.id} className="group relative">
-                    <a
-                      href={`/case-studies/${study.slug}`}
-                      className="absolute inset-0"
-                      aria-label={study.title}
-                    />
-                    <CardHeader>
-                      <CardTitle className="text-base group-hover:underline">{study.title}</CardTitle>
-                      <CardDescription>{study.summary}</CardDescription>
-                    </CardHeader>
-                  </Card>
-                ))}
-              </div>
-            </div>
-          ) : null}
-          {relatedArticles.length ? (
-            <div>
-              <h3 className="text-muted-foreground mb-2 text-sm font-medium uppercase">Articles</h3>
-              <div className="grid gap-4 md:grid-cols-2">
-                {relatedArticles.map((a) => (
-                  <Card key={a.id} className="group relative">
-                    <a
-                      href={`/articles/${a.slug}`}
-                      className="absolute inset-0"
-                      aria-label={a.title}
-                    />
-                    <CardHeader>
-                      <CardTitle className="text-base group-hover:underline">{a.title}</CardTitle>
-                      {a.summary ? <CardDescription>{a.summary}</CardDescription> : null}
-                    </CardHeader>
-                  </Card>
-                ))}
-              </div>
-            </div>
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-4 py-12 sm:px-6 sm:py-16">
+      <header className="space-y-4">
+        <AspectRatio ratio={16 / 9}>
+          <Image
+            src={article.hero_url || "/default-card.svg"}
+            alt=""
+            fill
+            sizes="100vw"
+            className="rounded-md object-cover"
+          />
+        </AspectRatio>
+        <div className="flex flex-wrap gap-2">
+          {article.tags.map((tag) => (
+            <Badge key={tag} variant="outline">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+        <div className="space-y-2">
+          <h1 className="text-4xl font-semibold tracking-tight">{article.title}</h1>
+          {article.summary ? (
+            <Card className="border-primary/30 bg-primary/5">
+              <CardHeader>
+                <CardTitle className="text-base">TL;DR</CardTitle>
+                <CardDescription className="text-foreground text-sm">
+                  {article.summary}
+                </CardDescription>
+              </CardHeader>
+            </Card>
           ) : null}
         </div>
-      </section>
-    );
+      </header>
+      {doc ? (
+        <MDXServer source={(doc as ArticleDoc).body.raw ?? ""} />
+      ) : (
+        <MDXServer source={supabaseMdx ?? ""} />
+      )}
+      <RelatedContent
+        articleId={article.id}
+        currentSlug={article.slug}
+        currentTags={article.tags}
+      />
+    </div>
+  );
+}
+
+async function RelatedContent({
+  articleId,
+  currentSlug,
+  currentTags,
+}: {
+  articleId: string;
+  currentSlug: string;
+  currentTags: string[];
+}) {
+  const [explicitProjects, explicitStudies, projects, studies, articles] = await Promise.all([
+    getRelatedProjectsForArticle(articleId),
+    getRelatedCaseStudiesForArticle(articleId),
+    getPublishedProjects(),
+    getPublishedCaseStudies(),
+    getPublishedArticles(),
+  ]);
+
+  const hasOverlap = (tags: string[]) => tags.some((tag) => currentTags.includes(tag));
+
+  const relatedProjects =
+    explicitProjects.length > 0
+      ? explicitProjects
+      : projects.filter((project) => hasOverlap(project.tags)).slice(0, 3);
+  const relatedStudies =
+    explicitStudies.length > 0
+      ? explicitStudies
+      : studies.filter((study) => hasOverlap(study.tags)).slice(0, 3);
+  const relatedArticles = articles
+    .filter((article) => article.slug !== currentSlug && hasOverlap(article.tags))
+    .slice(0, 3);
+
+  if (relatedProjects.length + relatedStudies.length + relatedArticles.length === 0) {
+    return null;
   }
+
+  return (
+    <section className="space-y-6">
+      <h2 className="text-2xl font-semibold">Related</h2>
+      <div className="grid gap-4">
+        {relatedProjects.length ? (
+          <div>
+            <h3 className="text-muted-foreground mb-2 text-sm font-medium uppercase">Projects</h3>
+            <div className="grid gap-4 md:grid-cols-2">
+              {relatedProjects.map((project) => (
+                <Card key={project.id} className="group relative">
+                  <a
+                    href={`/portfolio/${project.slug}`}
+                    className="absolute inset-0"
+                    aria-label={project.title}
+                  />
+                  <CardHeader>
+                    <CardTitle className="text-base group-hover:underline">
+                      {project.title}
+                    </CardTitle>
+                    <CardDescription>{project.summary}</CardDescription>
+                  </CardHeader>
+                </Card>
+              ))}
+            </div>
+          </div>
+        ) : null}
+        {relatedStudies.length ? (
+          <div>
+            <h3 className="text-muted-foreground mb-2 text-sm font-medium uppercase">
+              Case studies
+            </h3>
+            <div className="grid gap-4 md:grid-cols-2">
+              {relatedStudies.map((study) => (
+                <Card key={study.id} className="group relative">
+                  <a
+                    href={`/case-studies/${study.slug}`}
+                    className="absolute inset-0"
+                    aria-label={study.title}
+                  />
+                  <CardHeader>
+                    <CardTitle className="text-base group-hover:underline">{study.title}</CardTitle>
+                    <CardDescription>{study.summary}</CardDescription>
+                  </CardHeader>
+                </Card>
+              ))}
+            </div>
+          </div>
+        ) : null}
+        {relatedArticles.length ? (
+          <div>
+            <h3 className="text-muted-foreground mb-2 text-sm font-medium uppercase">Articles</h3>
+            <div className="grid gap-4 md:grid-cols-2">
+              {relatedArticles.map((article) => (
+                <Card key={article.id} className="group relative">
+                  <a
+                    href={`/articles/${article.slug}`}
+                    className="absolute inset-0"
+                    aria-label={article.title}
+                  />
+                  <CardHeader>
+                    <CardTitle className="text-base group-hover:underline">
+                      {article.title}
+                    </CardTitle>
+                    {article.summary ? <CardDescription>{article.summary}</CardDescription> : null}
+                  </CardHeader>
+                </Card>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -29,6 +29,11 @@ export default async function ProfilePage() {
                 {profile.hiring_status}
               </Badge>
             ) : null}
+            {profile?.pronouns ? (
+              <Badge variant="secondary" className="uppercase tracking-wide">
+                {profile.pronouns}
+              </Badge>
+            ) : null}
             {profile?.location ? (
               <span className="text-muted-foreground">{profile.location}</span>
             ) : null}
@@ -36,6 +41,9 @@ export default async function ProfilePage() {
           <h1 className="text-4xl font-semibold tracking-tight">
             {profile?.full_name ?? "Profile"}
           </h1>
+          {profile?.phonetic_name ? (
+            <p className="text-muted-foreground text-sm">Pronounced: {profile.phonetic_name}</p>
+          ) : null}
           {profile?.headline ? (
             <p className="text-muted-foreground text-lg">{profile.headline}</p>
           ) : null}
@@ -106,6 +114,37 @@ export default async function ProfilePage() {
           </CardContent>
         </Card>
       </section>
+
+      {(profile?.languages && profile.languages.length > 0) || profile?.access_notes ? (
+        <section className="grid gap-6 md:grid-cols-2">
+          {profile?.languages && profile.languages.length > 0 ? (
+            <Card>
+              <CardHeader>
+                <CardTitle>Languages</CardTitle>
+                <CardDescription>How I collaborate</CardDescription>
+              </CardHeader>
+              <CardContent className="text-muted-foreground text-sm">
+                <ul className="list-disc space-y-1 pl-5">
+                  {profile.languages?.map((language) => (
+                    <li key={language}>{language}</li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          ) : null}
+          {profile?.access_notes ? (
+            <Card>
+              <CardHeader>
+                <CardTitle>Access & preferences</CardTitle>
+                <CardDescription>Supportive collaboration</CardDescription>
+              </CardHeader>
+              <CardContent className="text-muted-foreground text-sm">
+                <p>{profile.access_notes}</p>
+              </CardContent>
+            </Card>
+          ) : null}
+        </section>
+      ) : null}
 
       {(profile?.speaking && profile.speaking.length > 0) ||
       (profile?.certifications && profile.certifications.length > 0) ||

--- a/lib/admin/queries.ts
+++ b/lib/admin/queries.ts
@@ -80,6 +80,34 @@ export async function fetchCaseStudyIdsByProject(): Promise<Record<string, strin
   return map;
 }
 
+export async function fetchArticleIdsByCaseStudy(): Promise<Record<string, string[]>> {
+  const admin = createSupabaseAdminClient();
+  const { data, error } = await admin
+    .from("article_related_case_studies")
+    .select("article_id, case_study_id");
+  if (error) throw new Error(error.message);
+  const map: Record<string, string[]> = {};
+  for (const row of (data as Array<{ article_id: string; case_study_id: string }> | null) ?? []) {
+    map[row.case_study_id] = map[row.case_study_id] || [];
+    map[row.case_study_id].push(row.article_id);
+  }
+  return map;
+}
+
+export async function fetchArticleIdsByProject(): Promise<Record<string, string[]>> {
+  const admin = createSupabaseAdminClient();
+  const { data, error } = await admin
+    .from("article_related_projects")
+    .select("article_id, project_id");
+  if (error) throw new Error(error.message);
+  const map: Record<string, string[]> = {};
+  for (const row of (data as Array<{ article_id: string; project_id: string }> | null) ?? []) {
+    map[row.project_id] = map[row.project_id] || [];
+    map[row.project_id].push(row.article_id);
+  }
+  return map;
+}
+
 export async function fetchRelationsForArticles(): Promise<
   Record<string, { projectIds: string[]; caseStudyIds: string[] }>
 > {

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -114,6 +114,10 @@ export type SiteProfile = {
   speaking?: string[] | null;
   certifications?: string[] | null;
   awards?: string[] | null;
+  pronouns?: string | null;
+  phonetic_name?: string | null;
+  languages?: string[] | null;
+  access_notes?: string | null;
   created_at: string;
   updated_at: string;
 };


### PR DESCRIPTION
## Summary
- restructure the case study admin modal to preload MDX content/preview, add a shared related checklist, and remove nested form usage
- allow projects and case studies to manage related articles via new admin queries and shared checklist component; clean up the article page to honor explicit relationships
- expand the site profile schema/UI with pronouns, phonetic name, languages, and access notes (including seed/init updates) and surface them on the public profile

## Testing
- pnpm lint
- pnpm exec prettier --check . --log-level warn
- pnpm typecheck
- pnpm test
- pnpm vercel-build *(fails: unable to fetch Geist fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4506df3f48325b3959e4c456d8030