### PR TITLE
Refactor case study metrics to JSON input

### DIFF
--- a/app/case-studies/[slug]/page.tsx
+++ b/app/case-studies/[slug]/page.tsx
@@ -6,13 +6,13 @@ import type { CaseStudyDoc } from "contentlayer/generated";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { MDXServer } from "@/components/mdx/mdx-server";
 import { findCaseStudyDoc, getMdxSourceOrNull } from "@/lib/content/resolve";
+import { caseStudyMetricsEntries } from "@/lib/case-studies/metrics";
 import {
   getCaseStudyBySlug,
   getVerticalProjects,
   getRelatedProjectsForCaseStudy,
 } from "@/lib/supabase/queries";
 import type { Vertical } from "@/lib/supabase/types";
-import { formatMetricKey } from "@/lib/utils";
 
 export default async function CaseStudyPage({ params }: { params: Promise<{ slug: string }> }) {
   const p = await params;
@@ -29,6 +29,7 @@ export default async function CaseStudyPage({ params }: { params: Promise<{ slug
   const relatedProjects = explicitRelated.length > 0 ? explicitRelated : verticalRelated;
   const doc = findCaseStudyDoc(caseStudy.body_path ?? "");
   const supabaseMdx = doc ? null : await getMdxSourceOrNull(caseStudy.body_path ?? "");
+  const metrics = caseStudyMetricsEntries(caseStudy.metrics);
 
   return (
     <div className="mx-auto flex w-full max-w-4xl flex-col gap-10 px-4 py-12 sm:px-6 sm:py-16">
@@ -51,13 +52,13 @@ export default async function CaseStudyPage({ params }: { params: Promise<{ slug
 
       <section className="space-y-3">
         <h2 className="text-2xl font-semibold">Results</h2>
-        {caseStudy.metrics ? (
+        {metrics.length ? (
           <div className="grid gap-4 sm:grid-cols-2">
-            {Object.entries(caseStudy.metrics).map(([metric, value]) => (
-              <Card key={metric}>
+            {metrics.map((metric) => (
+              <Card key={metric.key}>
                 <CardHeader>
-                  <CardTitle className="text-base">{formatMetricKey(metric)}</CardTitle>
-                  <CardDescription>{value}</CardDescription>
+                  <CardTitle className="text-base">{metric.title}</CardTitle>
+                  <CardDescription>{metric.description}</CardDescription>
                 </CardHeader>
               </Card>
             ))}

--- a/app/case-studies/page.tsx
+++ b/app/case-studies/page.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { AspectRatio } from "@/components/ui/aspect-ratio";
+import { caseStudyMetricsEntries } from "@/lib/case-studies/metrics";
 import {
   getPublishedCaseStudies,
   getPublishedProjects,
@@ -45,13 +46,15 @@ export default async function CaseStudiesPage({
         <p className="text-muted-foreground text-sm">No case studies found.</p>
       ) : (
         <div className="grid gap-6 md:grid-cols-2">
-          {filtered.map((study) => (
-            <Card key={study.id} className="group relative flex flex-col overflow-hidden">
-              <Link
-                href={`/case-studies/${study.slug}`}
-                className="absolute inset-0"
-                aria-label={study.title}
-              />
+          {filtered.map((study) => {
+            const metrics = caseStudyMetricsEntries(study.metrics).slice(0, 3);
+            return (
+              <Card key={study.id} className="group relative flex flex-col overflow-hidden">
+                <Link
+                  href={`/case-studies/${study.slug}`}
+                  className="absolute inset-0"
+                  aria-label={study.title}
+                />
               <AspectRatio ratio={16 / 9}>
                 <Image
                   src={study.hero_url || "/default-card.svg"}
@@ -68,15 +71,13 @@ export default async function CaseStudiesPage({
                 <CardDescription>{study.summary}</CardDescription>
               </CardHeader>
               <CardContent className="mt-auto space-y-3 text-sm">
-                {study.metrics ? (
+                {metrics.length ? (
                   <ul className="text-muted-foreground list-disc space-y-1 pl-5">
-                    {Object.entries(study.metrics)
-                      .slice(0, 3)
-                      .map(([metric, value]) => (
-                        <li key={metric}>
-                          <span className="text-foreground font-medium">{metric}:</span> {value}
-                        </li>
-                      ))}
+                    {metrics.map((metric) => (
+                      <li key={metric.key}>
+                        <span className="text-foreground font-medium">{metric.title}:</span> {metric.description}
+                      </li>
+                    ))}
                   </ul>
                 ) : null}
                 <div className="flex flex-wrap gap-2">
@@ -113,8 +114,9 @@ export default async function CaseStudiesPage({
                 </div>
                 <span className="text-primary">Read case study →</span>
               </CardContent>
-            </Card>
-          ))}
+              </Card>
+            );
+          })}
         </div>
       )}
     </div>

--- a/app/verticals/[slug]/page.tsx
+++ b/app/verticals/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import Image from "next/image";
 import { AspectRatio } from "@/components/ui/aspect-ratio";
+import { caseStudyMetricsEntries } from "@/lib/case-studies/metrics";
 import {
   getVerticalArticles,
   getVerticalCaseStudies,
@@ -120,16 +121,12 @@ export default async function VerticalDetailPage({
                 <CardContent className="text-sm">
                   <p className="text-foreground font-medium">Metrics</p>
                   <ul className="text-muted-foreground mt-2 space-y-1">
-                    {study.metrics
-                      ? Object.entries(study.metrics).map(([metric, value]) => (
-                          <li key={metric}>
-                            <span className="text-foreground font-medium">
-                              {formatMetricKey(metric)}:
-                            </span>{" "}
-                            {value}
-                          </li>
-                        ))
-                      : null}
+                    {caseStudyMetricsEntries(study.metrics).map((metric) => (
+                      <li key={metric.key}>
+                        <span className="text-foreground font-medium">{metric.title}:</span>{" "}
+                        {metric.description}
+                      </li>
+                    ))}
                   </ul>
                 </CardContent>
               </Card>

--- a/lib/case-studies/metrics.ts
+++ b/lib/case-studies/metrics.ts
@@ -1,0 +1,185 @@
+import { formatMetricKey } from "@/lib/utils";
+import type { CaseStudyMetrics } from "@/lib/supabase/types";
+
+export type CaseStudyMetricDetail = {
+  title: string;
+  description: string;
+};
+
+export type CaseStudyMetricRecord = Record<string, CaseStudyMetricDetail>;
+
+export type CaseStudyMetricEntry = CaseStudyMetricDetail & { key: string };
+
+type SanitizeOptions = {
+  strict?: boolean;
+};
+
+const TITLE_KEYS = ["title", "Title"] as const;
+const DESCRIPTION_KEYS = ["description", "Description"] as const;
+
+function defaultMetricTitle(key: string): string {
+  const trimmed = key.trim();
+  if (!trimmed) return "";
+  if (/^[A-Z0-9]+$/.test(trimmed)) return trimmed;
+  if (/^[a-z0-9]+$/.test(trimmed) && trimmed.length <= 4) {
+    return trimmed.toUpperCase();
+  }
+  if (/[\s_-]/.test(trimmed)) return formatMetricKey(trimmed);
+  return formatMetricKey(trimmed);
+}
+
+function getStringValue(
+  source: Record<string, unknown>,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function sanitizeCaseStudyMetricsRecord(
+  record: Record<string, unknown>,
+  options: SanitizeOptions = {},
+): CaseStudyMetricRecord {
+  const entries = Object.entries(record);
+  const result: CaseStudyMetricRecord = {};
+
+  for (const [rawKey, rawValue] of entries) {
+    const key = rawKey?.toString().trim();
+    if (!key) {
+      if (options.strict) {
+        throw new Error("Metric keys must be non-empty strings.");
+      }
+      continue;
+    }
+
+    if (rawValue == null) {
+      if (options.strict) {
+        throw new Error(`Metric "${key}" must include details.`);
+      }
+      continue;
+    }
+
+    if (typeof rawValue === "string") {
+      if (options.strict) {
+        throw new Error(
+          `Metric "${key}" must be an object with title and description fields.`,
+        );
+      }
+      const description = rawValue.trim();
+      if (!description) continue;
+      result[key] = {
+        title: defaultMetricTitle(key),
+        description,
+      };
+      continue;
+    }
+
+    if (typeof rawValue !== "object" || Array.isArray(rawValue)) {
+      if (options.strict) {
+        throw new Error(
+          `Metric "${key}" must be an object with title and description fields.`,
+        );
+      }
+      continue;
+    }
+
+    const valueRecord = rawValue as Record<string, unknown>;
+    const title = getStringValue(valueRecord, TITLE_KEYS);
+    const description = getStringValue(valueRecord, DESCRIPTION_KEYS);
+
+    if (!title || !description) {
+      if (options.strict) {
+        throw new Error(`Metric "${key}" must include title and description.`);
+      }
+      if (!description) continue;
+      result[key] = {
+        title: title ?? defaultMetricTitle(key),
+        description,
+      };
+      continue;
+    }
+
+    result[key] = {
+      title,
+      description,
+    };
+  }
+
+  return result;
+}
+
+export function normalizeCaseStudyMetrics(
+  metrics: CaseStudyMetrics | null | undefined,
+): CaseStudyMetricRecord {
+  if (!metrics) return {};
+  if (typeof metrics !== "object" || Array.isArray(metrics)) return {};
+  return sanitizeCaseStudyMetricsRecord(metrics as Record<string, unknown>);
+}
+
+export function caseStudyMetricsEntries(
+  metrics: CaseStudyMetrics | null | undefined,
+): CaseStudyMetricEntry[] {
+  const normalized = normalizeCaseStudyMetrics(metrics);
+  return Object.entries(normalized).map(([key, value]) => ({
+    key,
+    title: value.title,
+    description: value.description,
+  }));
+}
+
+export function parseCaseStudyMetricsInput(
+  input: string | Record<string, unknown> | null | undefined,
+): CaseStudyMetricRecord {
+  if (!input) return {};
+  if (typeof input === "object") {
+    return sanitizeCaseStudyMetricsRecord(input, { strict: true });
+  }
+  const trimmed = input.trim();
+  if (!trimmed) return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    throw new Error("Metrics must be valid JSON.");
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Metrics JSON must be an object of metric entries.");
+  }
+
+  return sanitizeCaseStudyMetricsRecord(parsed as Record<string, unknown>, {
+    strict: true,
+  });
+}
+
+export function coerceCaseStudyMetrics(
+  input: unknown,
+  options: SanitizeOptions = {},
+): CaseStudyMetricRecord {
+  if (!input) return {};
+  if (typeof input === "string") {
+    return parseCaseStudyMetricsInput(input);
+  }
+  if (typeof input === "object" && !Array.isArray(input)) {
+    return sanitizeCaseStudyMetricsRecord(input as Record<string, unknown>, options);
+  }
+  if (options.strict) {
+    throw new Error("Metrics must be provided as a JSON object.");
+  }
+  return {};
+}
+
+export function metricsToTextareaValue(
+  metrics: CaseStudyMetrics | null | undefined,
+): string {
+  const normalized = normalizeCaseStudyMetrics(metrics);
+  const keys = Object.keys(normalized);
+  if (keys.length === 0) return "";
+  return JSON.stringify(normalized, null, 2);
+}

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -22,7 +22,17 @@ export type Project = {
   updated_at: string;
 };
 
-export type CaseStudyMetrics = Record<string, string> | null;
+export type CaseStudyMetricValue =
+  | string
+  | {
+      title?: string;
+      Title?: string;
+      description?: string;
+      Description?: string;
+      [key: string]: unknown;
+    };
+
+export type CaseStudyMetrics = Record<string, CaseStudyMetricValue> | null;
 
 export type CaseStudy = {
   id: string;

--- a/scripts/mock-google-fonts.js
+++ b/scripts/mock-google-fonts.js
@@ -1,0 +1,4 @@
+module.exports = {
+  "https://fonts.googleapis.com/css2?family=Geist:wght@100..900&display=swap": `@font-face {\n  font-family: 'Geist';\n  font-style: normal;\n  font-weight: 400;\n  font-display: swap;\n  src: url(/workspace/portfolio/tests/__mocks__/fonts/Geist.woff2) format('woff2');\n}\n`,
+  "https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100..900&display=swap": `@font-face {\n  font-family: 'Geist Mono';\n  font-style: normal;\n  font-weight: 400;\n  font-display: swap;\n  src: url(/workspace/portfolio/tests/__mocks__/fonts/GeistMono.woff2) format('woff2');\n}\n`,
+};

--- a/tests/__mocks__/fonts/Geist.woff2
+++ b/tests/__mocks__/fonts/Geist.woff2
@@ -1,0 +1,1 @@
+dummy font

--- a/tests/__mocks__/fonts/GeistMono.woff2
+++ b/tests/__mocks__/fonts/GeistMono.woff2
@@ -1,0 +1,1 @@
+dummy font

--- a/tests/case-study-metrics.test.ts
+++ b/tests/case-study-metrics.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  caseStudyMetricsEntries,
+  coerceCaseStudyMetrics,
+  metricsToTextareaValue,
+  normalizeCaseStudyMetrics,
+  parseCaseStudyMetricsInput,
+} from "@/lib/case-studies/metrics";
+
+describe("parseCaseStudyMetricsInput", () => {
+  it("parses a valid JSON string and preserves title case", () => {
+    const input = `{
+      "1": { "title": "ROI", "description": "200% return" },
+      "2": { "title": "Time to Value", "description": "Launched in 4 weeks" }
+    }`;
+
+    const result = parseCaseStudyMetricsInput(input);
+
+    expect(result).toEqual({
+      "1": { title: "ROI", description: "200% return" },
+      "2": { title: "Time to Value", description: "Launched in 4 weeks" },
+    });
+  });
+
+  it("throws when a metric is missing required fields", () => {
+    const input = `{"1": { "title": "ROI" }}`;
+
+    expect(() => parseCaseStudyMetricsInput(input)).toThrow(
+      /must include title and description/i,
+    );
+  });
+});
+
+describe("coerceCaseStudyMetrics", () => {
+  it("coerces legacy string values", () => {
+    const input = {
+      roi: "200% return",
+      deployment_frequency: "Shipped weekly",
+    };
+
+    const result = coerceCaseStudyMetrics(input);
+
+    expect(result).toEqual({
+      roi: { title: "ROI", description: "200% return" },
+      deployment_frequency: {
+        title: "Deployment Frequency",
+        description: "Shipped weekly",
+      },
+    });
+  });
+});
+
+describe("normalizeCaseStudyMetrics", () => {
+  it("normalizes various input shapes for display", () => {
+    const input = {
+      "1": { Title: "ROI", Description: "200%" },
+      "2": { title: "MTTR", description: "Under 30 minutes" },
+    };
+
+    const normalized = normalizeCaseStudyMetrics(input);
+    const entries = caseStudyMetricsEntries(input);
+
+    expect(normalized).toEqual({
+      "1": { title: "ROI", description: "200%" },
+      "2": { title: "MTTR", description: "Under 30 minutes" },
+    });
+    expect(entries).toEqual([
+      { key: "1", title: "ROI", description: "200%" },
+      { key: "2", title: "MTTR", description: "Under 30 minutes" },
+    ]);
+  });
+});
+
+describe("metricsToTextareaValue", () => {
+  it("serializes metrics to formatted JSON", () => {
+    const input = {
+      "1": { title: "ROI", description: "200%" },
+    };
+
+    expect(metricsToTextareaValue(input)).toBe(
+      '{\n  "1": {\n    "title": "ROI",\n    "description": "200%"\n  }\n}',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- convert the case study admin form to accept structured JSON metrics and surface a dropdown for featured selections
- update Supabase types, page rendering, and new utilities to normalize and parse the metrics everywhere they are displayed
- add regression tests for metric parsing and provide mocked Google Fonts responses to allow offline builds

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test -- --run tests/case-study-metrics.test.ts
- CI=1 NEXT_FONT_GOOGLE_MOCKED_RESPONSES=$(pwd)/scripts/mock-google-fonts.js pnpm vercel-build

------
https://chatgpt.com/codex/tasks/task_e_68d5afb71b0883258fecbab69adb3e25