### PR TITLE
Redesign profile experience and admin tooling

### DIFF
--- a/.docs/SUPABASE_INIT.sql
+++ b/.docs/SUPABASE_INIT.sql
@@ -193,6 +193,88 @@ create table if not exists public.site_profile (
   updated_at timestamptz not null default now()
 );
 
+alter table public.site_profile add column if not exists pronouns text;
+alter table public.site_profile add column if not exists phonetic_name text;
+alter table public.site_profile add column if not exists philosophy text;
+alter table public.site_profile add column if not exists cta_primary_label text;
+alter table public.site_profile add column if not exists cta_primary_url text;
+alter table public.site_profile add column if not exists cta_secondary_label text;
+alter table public.site_profile add column if not exists cta_secondary_url text;
+alter table public.site_profile add column if not exists career_cta_label text;
+alter table public.site_profile add column if not exists career_cta_url text;
+
+create table if not exists public.profile_pillars (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  description text not null,
+  icon_slug text,
+  link_label text,
+  link_url text,
+  order_index integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index if not exists profile_pillars_order_idx on public.profile_pillars (order_index, created_at);
+
+create table if not exists public.profile_career_highlights (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  description text not null,
+  link_label text,
+  link_url text,
+  order_index integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index if not exists profile_career_highlights_order_idx on public.profile_career_highlights (order_index, created_at);
+
+create table if not exists public.profile_speaking_engagements (
+  id uuid primary key default gen_random_uuid(),
+  event text not null,
+  title text,
+  year text,
+  link_url text,
+  order_index integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index if not exists profile_speaking_engagements_order_idx on public.profile_speaking_engagements (order_index, created_at);
+
+create table if not exists public.profile_recognitions (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  issuer text,
+  year text,
+  link_url text,
+  order_index integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index if not exists profile_recognitions_order_idx on public.profile_recognitions (order_index, created_at);
+
+create table if not exists public.profile_testimonials (
+  id uuid primary key default gen_random_uuid(),
+  quote text not null,
+  attribution text not null,
+  role text,
+  link_url text,
+  order_index integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index if not exists profile_testimonials_order_idx on public.profile_testimonials (order_index, created_at);
+
+create table if not exists public.profile_personal_entries (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  description text not null,
+  icon_slug text,
+  order_index integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index if not exists profile_personal_entries_order_idx on public.profile_personal_entries (order_index, created_at);
+
 create table if not exists public.contact_links (
   id uuid primary key default gen_random_uuid(),
   label text not null,
@@ -247,6 +329,12 @@ alter table public.site_settings enable row level security;
 alter table public.site_profile  enable row level security;
 alter table public.contact_links enable row level security;
 alter table public.contact_requests enable row level security;
+alter table public.profile_pillars enable row level security;
+alter table public.profile_career_highlights enable row level security;
+alter table public.profile_speaking_engagements enable row level security;
+alter table public.profile_recognitions enable row level security;
+alter table public.profile_testimonials enable row level security;
+alter table public.profile_personal_entries enable row level security;
 
 -- Notifications ------------------------------------------------------
 -- Ensure settings table exists (add template columns if missing)
@@ -375,6 +463,42 @@ begin
     select 1 from pg_policies where schemaname='public' and tablename='site_profile' and policyname='site_profile_public_read'
   ) then
     execute 'create policy "site_profile_public_read" on public.site_profile for select to public using (true);';
+  end if;
+
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='profile_pillars' and policyname='profile_pillars_public_read'
+  ) then
+    execute 'create policy "profile_pillars_public_read" on public.profile_pillars for select to public using (true);';
+  end if;
+
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='profile_career_highlights' and policyname='profile_career_highlights_public_read'
+  ) then
+    execute 'create policy "profile_career_highlights_public_read" on public.profile_career_highlights for select to public using (true);';
+  end if;
+
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='profile_speaking_engagements' and policyname='profile_speaking_engagements_public_read'
+  ) then
+    execute 'create policy "profile_speaking_engagements_public_read" on public.profile_speaking_engagements for select to public using (true);';
+  end if;
+
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='profile_recognitions' and policyname='profile_recognitions_public_read'
+  ) then
+    execute 'create policy "profile_recognitions_public_read" on public.profile_recognitions for select to public using (true);';
+  end if;
+
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='profile_testimonials' and policyname='profile_testimonials_public_read'
+  ) then
+    execute 'create policy "profile_testimonials_public_read" on public.profile_testimonials for select to public using (true);';
+  end if;
+
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='profile_personal_entries' and policyname='profile_personal_entries_public_read'
+  ) then
+    execute 'create policy "profile_personal_entries_public_read" on public.profile_personal_entries for select to public using (true);';
   end if;
 
   if not exists (

--- a/.docs/SUPABASE_SEED.sql
+++ b/.docs/SUPABASE_SEED.sql
@@ -306,6 +306,7 @@ insert into public.site_profile (
   headline,
   subheadline,
   summary,
+  philosophy,
   avatar_url,
   location,
   hiring_status,
@@ -319,7 +320,13 @@ insert into public.site_profile (
   pronouns,
   phonetic_name,
   languages,
-  access_notes
+  access_notes,
+  cta_primary_label,
+  cta_primary_url,
+  cta_secondary_label,
+  cta_secondary_url,
+  career_cta_label,
+  career_cta_url
 )
 values (
   '22222222-2222-2222-2222-222222222222',
@@ -327,6 +334,7 @@ values (
   'Security-first engineering leader for AI-driven platforms.',
   'Operationalizing AI security, secure delivery, and SOC automation.',
   'Trusted advisor helping CTO/CISO teams ship boldly without compromising trust.',
+  'I believe security is a growth lever. I design guardrails that make experimentation safer, faster, and more accountable.',
   'https://jkonghamlxbaoeytefvs.supabase.co/storage/v1/object/public/images/profile_photo.jpg',
   'San Francisco Bay Area · Remote-friendly',
   'Open to Director/Principal security platform roles',
@@ -340,13 +348,20 @@ values (
   'he/him',
   'JEFF WEE-bur',
   '["English (native)","Spanish (conversational)"]'::jsonb,
-  'Happy to accommodate ASL interpreters and flexible meeting hours across time zones.'
+  'Happy to accommodate ASL interpreters and flexible meeting hours across time zones.',
+  'Explore my work',
+  '/portfolio',
+  'Contact me',
+  'mailto:jeff@example.com',
+  'Read full case studies →',
+  '/case-studies'
 )
 on conflict (id) do update set
   full_name = excluded.full_name,
   headline = excluded.headline,
   subheadline = excluded.subheadline,
   summary = excluded.summary,
+  philosophy = excluded.philosophy,
   avatar_url = excluded.avatar_url,
   location = excluded.location,
   hiring_status = excluded.hiring_status,
@@ -361,6 +376,246 @@ on conflict (id) do update set
   phonetic_name = excluded.phonetic_name,
   languages = excluded.languages,
   access_notes = excluded.access_notes,
+  cta_primary_label = excluded.cta_primary_label,
+  cta_primary_url = excluded.cta_primary_url,
+  cta_secondary_label = excluded.cta_secondary_label,
+  cta_secondary_url = excluded.cta_secondary_url,
+  career_cta_label = excluded.career_cta_label,
+  career_cta_url = excluded.career_cta_url,
+  updated_at = now();
+
+-- Profile pillars -------------------------------------------------------------
+insert into public.profile_pillars (id, title, description, icon_slug, link_label, link_url, order_index)
+values
+  (
+    '33333333-3333-4333-8333-333333333331',
+    'AI Security',
+    'Emerging risks, access governance, and securing self-hosted models for enterprises.',
+    'openai',
+    'View AI security work',
+    '/portfolio?tag=ai-security',
+    0
+  ),
+  (
+    '33333333-3333-4333-8333-333333333332',
+    'DevSecOps & Supply Chain',
+    'SLSA-aligned pipelines, SBOM automation, CodeQL/GHAS adoption, and developer enablement.',
+    'githubactions',
+    'See secure delivery wins',
+    '/portfolio?tag=secure-devops',
+    1
+  ),
+  (
+    '33333333-3333-4333-8333-333333333333',
+    'SOC Automation & Detection',
+    'Python/Splunk automation, enrichment pipelines, and MTTR cuts without extra headcount.',
+    'splunk',
+    'Explore SOC outcomes',
+    '/portfolio?tag=soc',
+    2
+  ),
+  (
+    '33333333-3333-4333-8333-333333333334',
+    'Zero Trust & IAM',
+    'Privileged access, BeyondCorp patterns, and removing shared accounts at scale.',
+    'okta',
+    'Dive into IAM transformations',
+    '/case-studies',
+    3
+  )
+on conflict (id) do update set
+  title = excluded.title,
+  description = excluded.description,
+  icon_slug = excluded.icon_slug,
+  link_label = excluded.link_label,
+  link_url = excluded.link_url,
+  order_index = excluded.order_index,
+  updated_at = now();
+
+-- Career highlights -----------------------------------------------------------
+insert into public.profile_career_highlights (id, title, description, link_label, link_url, order_index)
+values
+  (
+    '44444444-4444-4444-8444-444444444441',
+    'SAIC',
+    'SOC automation program cut MTTR and returned 20 analyst hours weekly.',
+    null,
+    null,
+    0
+  ),
+  (
+    '44444444-4444-4444-8444-444444444442',
+    'Atmosera',
+    'Global IAM re-architecture introducing PAM, RBAC, and audit-ready controls.',
+    null,
+    null,
+    1
+  ),
+  (
+    '44444444-4444-4444-8444-444444444443',
+    'SheppTech',
+    'Founded consulting practice leading cloud security and client delivery.',
+    null,
+    null,
+    2
+  ),
+  (
+    '44444444-4444-4444-8444-444444444444',
+    'Mastery',
+    'SOC 2 remediation, Sentinel automations, and resilient IR playbooks.',
+    null,
+    null,
+    3
+  ),
+  (
+    '44444444-4444-4444-8444-444444444445',
+    'Army',
+    'High-stakes security discipline across presidential mission support.',
+    null,
+    null,
+    4
+  )
+on conflict (id) do update set
+  title = excluded.title,
+  description = excluded.description,
+  link_label = excluded.link_label,
+  link_url = excluded.link_url,
+  order_index = excluded.order_index,
+  updated_at = now();
+
+-- Speaking -------------------------------------------------------------------
+insert into public.profile_speaking_engagements (id, event, title, year, link_url, order_index)
+values
+  (
+    '55555555-5555-4555-8555-555555555551',
+    'DEF CON Workshop',
+    'SOC automation strategies for hybrid cloud',
+    '2024',
+    'https://defcon.org/workshops/soc-automation',
+    0
+  ),
+  (
+    '55555555-5555-4555-8555-555555555552',
+    'BSides Seattle',
+    'Zero Trust adoption lessons from regulated teams',
+    '2023',
+    'https://bsidesseattle.com/talks/zero-trust-lessons',
+    1
+  )
+on conflict (id) do update set
+  event = excluded.event,
+  title = excluded.title,
+  year = excluded.year,
+  link_url = excluded.link_url,
+  order_index = excluded.order_index,
+  updated_at = now();
+
+-- Recognition ----------------------------------------------------------------
+insert into public.profile_recognitions (id, title, issuer, year, link_url, order_index)
+values
+  (
+    '66666666-6666-4666-8666-666666666661',
+    'CISSP',
+    'ISC²',
+    '2015',
+    'https://www.isc2.org/certifications/cissp',
+    0
+  ),
+  (
+    '66666666-6666-4666-8666-666666666662',
+    'OSCP',
+    'OffSec',
+    '2017',
+    'https://www.offsec.com/courses/pen-200/',
+    1
+  ),
+  (
+    '66666666-6666-4666-8666-666666666663',
+    'Featured in Supabase Launch Week',
+    'Supabase',
+    '2024',
+    'https://supabase.com/blog',
+    2
+  )
+on conflict (id) do update set
+  title = excluded.title,
+  issuer = excluded.issuer,
+  year = excluded.year,
+  link_url = excluded.link_url,
+  order_index = excluded.order_index,
+  updated_at = now();
+
+-- Testimonials ---------------------------------------------------------------
+insert into public.profile_testimonials (id, quote, attribution, role, link_url, order_index)
+values
+  (
+    '77777777-7777-4777-8777-777777777771',
+    '“Jeff’s automation work fundamentally changed our SOC efficiency.”',
+    'Manager, SAIC',
+    'Security Operations Leader',
+    null,
+    0
+  ),
+  (
+    '77777777-7777-4777-8777-777777777772',
+    '“He led PAM re-architecture that exceeded audit requirements across a global enterprise.”',
+    'Senior Consultant, Atmosera',
+    'PAM Program Lead',
+    null,
+    1
+  ),
+  (
+    '77777777-7777-4777-8777-777777777773',
+    '“Hands-down the most pragmatic partner we’ve had for AI security.”',
+    'Head of Platform, Mastery',
+    null,
+    null,
+    2
+  )
+on conflict (id) do update set
+  quote = excluded.quote,
+  attribution = excluded.attribution,
+  role = excluded.role,
+  link_url = excluded.link_url,
+  order_index = excluded.order_index,
+  updated_at = now();
+
+-- Beyond security ------------------------------------------------------------
+insert into public.profile_personal_entries (id, title, description, icon_slug, order_index)
+values
+  (
+    '88888888-8888-4888-8888-888888888881',
+    'Interests',
+    'AI safety, homelab engineering, security research.',
+    'homeassistant',
+    0
+  ),
+  (
+    '88888888-8888-4888-8888-888888888882',
+    'Languages',
+    'English (native), Spanish (conversational).',
+    'googletranslate',
+    1
+  ),
+  (
+    '88888888-8888-4888-8888-888888888883',
+    'Hobbies',
+    'Fitness, gourmet mushroom cultivation, woodworking.',
+    'strava',
+    2
+  ),
+  (
+    '88888888-8888-4888-8888-888888888884',
+    'Collaboration Style',
+    'Direct, pragmatic, outcome-driven partner with crisp communication.',
+    'slack',
+    3
+  )
+on conflict (id) do update set
+  title = excluded.title,
+  description = excluded.description,
+  icon_slug = excluded.icon_slug,
+  order_index = excluded.order_index,
   updated_at = now();
 
 -- Contact links --------------------------------------------------------------

--- a/app/admin/(dashboard)/site-profile/actions.ts
+++ b/app/admin/(dashboard)/site-profile/actions.ts
@@ -218,21 +218,15 @@ async function deleteRow(formData: FormData, table: string, status: string, labe
 }
 
 export async function upsertProfilePillar(formData: FormData) {
-  return upsertRow(
-    formData,
-    pillarSchema,
-    "profile_pillars",
-    "pillar-saved",
-    (payload) => ({
-      id: payload.id,
-      title: payload.title,
-      description: payload.description,
-      icon_slug: cleanText(payload.icon_slug),
-      link_label: cleanText(payload.link_label),
-      link_url: cleanText(payload.link_url),
-      order_index: orderValue(payload.order_index, 0),
-    }),
-  );
+  return upsertRow(formData, pillarSchema, "profile_pillars", "pillar-saved", (payload) => ({
+    id: payload.id,
+    title: payload.title,
+    description: payload.description,
+    icon_slug: cleanText(payload.icon_slug),
+    link_label: cleanText(payload.link_label),
+    link_url: cleanText(payload.link_url),
+    order_index: orderValue(payload.order_index, 0),
+  }));
 }
 
 export async function deleteProfilePillar(formData: FormData) {

--- a/app/admin/(dashboard)/site-profile/actions.ts
+++ b/app/admin/(dashboard)/site-profile/actions.ts
@@ -13,90 +13,332 @@ const profileSchema = z.object({
   headline: z.string().min(1),
   subheadline: z.string().optional(),
   summary: z.string().optional(),
+  philosophy: z.string().optional(),
   avatar_url: z.string().optional(),
   location: z.string().optional(),
   hiring_status: z.string().optional(),
   resume_preference: z.enum(["ai-security", "secure-devops", "soc"]),
-  hobbies: z.string().optional(),
-  interests: z.string().optional(),
-  speaking: z.string().optional(),
-  certifications: z.string().optional(),
-  awards: z.string().optional(),
   pronouns: z.string().optional(),
   phonetic_name: z.string().optional(),
-  languages: z.string().optional(),
-  access_notes: z.string().optional(),
+  cta_primary_label: z.string().optional(),
+  cta_primary_url: z.string().optional(),
+  cta_secondary_label: z.string().optional(),
+  cta_secondary_url: z.string().optional(),
+  career_cta_label: z.string().optional(),
+  career_cta_url: z.string().optional(),
 });
+
+const orderField = z.coerce.number().int().min(0).optional();
+
+const pillarSchema = z.object({
+  id: z.string().optional(),
+  title: z.string().min(1),
+  description: z.string().min(1),
+  icon_slug: z.string().optional(),
+  link_label: z.string().optional(),
+  link_url: z.string().optional(),
+  order_index: orderField,
+});
+
+const careerSchema = z.object({
+  id: z.string().optional(),
+  title: z.string().min(1),
+  description: z.string().min(1),
+  link_label: z.string().optional(),
+  link_url: z.string().optional(),
+  order_index: orderField,
+});
+
+const speakingSchema = z.object({
+  id: z.string().optional(),
+  event: z.string().min(1),
+  title: z.string().optional(),
+  year: z.string().optional(),
+  link_url: z.string().optional(),
+  order_index: orderField,
+});
+
+const recognitionSchema = z.object({
+  id: z.string().optional(),
+  title: z.string().min(1),
+  issuer: z.string().optional(),
+  year: z.string().optional(),
+  link_url: z.string().optional(),
+  order_index: orderField,
+});
+
+const testimonialSchema = z.object({
+  id: z.string().optional(),
+  quote: z.string().min(1),
+  attribution: z.string().min(1),
+  role: z.string().optional(),
+  link_url: z.string().optional(),
+  order_index: orderField,
+});
+
+const personalSchema = z.object({
+  id: z.string().optional(),
+  title: z.string().min(1),
+  description: z.string().min(1),
+  icon_slug: z.string().optional(),
+  order_index: orderField,
+});
+
+function getString(formData: FormData, key: string) {
+  const value = formData.get(key);
+  return typeof value === "string" ? value : undefined;
+}
+
+function cleanText(value: string | undefined) {
+  const trimmed = (value ?? "").trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function orderValue(value: number | undefined, fallback = 0) {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function revalidateProfile() {
+  revalidatePath("/");
+  revalidatePath("/profile");
+  revalidatePath("/admin/site-profile");
+}
 
 export async function upsertSiteProfile(formData: FormData) {
   await requireAdminUser();
 
   const payload = profileSchema.parse({
-    id: formData.get("id")?.toString() || undefined,
-    full_name: formData.get("full_name")?.toString() ?? "",
-    headline: formData.get("headline")?.toString() ?? "",
-    subheadline: formData.get("subheadline")?.toString() ?? "",
-    summary: formData.get("summary")?.toString() ?? "",
-    avatar_url: formData.get("avatar_url")?.toString() ?? "",
-    location: formData.get("location")?.toString() ?? "",
-    hiring_status: formData.get("hiring_status")?.toString() ?? "",
-    resume_preference: (formData.get("resume_preference")?.toString() ?? "ai-security") as
+    id: getString(formData, "id"),
+    full_name: getString(formData, "full_name") ?? "",
+    headline: getString(formData, "headline") ?? "",
+    subheadline: getString(formData, "subheadline"),
+    summary: getString(formData, "summary"),
+    philosophy: getString(formData, "philosophy"),
+    avatar_url: getString(formData, "avatar_url"),
+    location: getString(formData, "location"),
+    hiring_status: getString(formData, "hiring_status"),
+    resume_preference: (getString(formData, "resume_preference") ?? "ai-security") as
       | "ai-security"
       | "secure-devops"
       | "soc",
-    hobbies: formData.get("hobbies")?.toString() ?? "",
-    interests: formData.get("interests")?.toString() ?? "",
-    speaking: formData.get("speaking")?.toString() ?? "",
-    certifications: formData.get("certifications")?.toString() ?? "",
-    awards: formData.get("awards")?.toString() ?? "",
-    pronouns: formData.get("pronouns")?.toString() ?? "",
-    phonetic_name: formData.get("phonetic_name")?.toString() ?? "",
-    languages: formData.get("languages")?.toString() ?? "",
-    access_notes: formData.get("access_notes")?.toString() ?? "",
+    pronouns: getString(formData, "pronouns"),
+    phonetic_name: getString(formData, "phonetic_name"),
+    cta_primary_label: getString(formData, "cta_primary_label"),
+    cta_primary_url: getString(formData, "cta_primary_url"),
+    cta_secondary_label: getString(formData, "cta_secondary_label"),
+    cta_secondary_url: getString(formData, "cta_secondary_url"),
+    career_cta_label: getString(formData, "career_cta_label"),
+    career_cta_url: getString(formData, "career_cta_url"),
   });
 
   const admin = createSupabaseAdminClient();
-
-  const toLines = (s: string) =>
-    s
-      .split(/\r?\n/)
-      .map((l) => l.trim())
-      .filter(Boolean);
-
-  const cleanText = (value: string | undefined) => {
-    const trimmed = (value ?? "").trim();
-    return trimmed.length > 0 ? trimmed : null;
-  };
-
   const { error } = await admin.from("site_profile").upsert({
     id: payload.id,
     full_name: payload.full_name,
     headline: payload.headline,
-    subheadline: payload.subheadline,
-    summary: payload.summary,
-    avatar_url: payload.avatar_url,
-    location: payload.location,
-    hiring_status: payload.hiring_status,
+    subheadline: cleanText(payload.subheadline),
+    summary: cleanText(payload.summary),
+    philosophy: cleanText(payload.philosophy),
+    avatar_url: cleanText(payload.avatar_url),
+    location: cleanText(payload.location),
+    hiring_status: cleanText(payload.hiring_status),
     resume_preference: payload.resume_preference,
-    hobbies: toLines(payload.hobbies ?? ""),
-    interests: toLines(payload.interests ?? ""),
-    speaking: toLines(payload.speaking ?? ""),
-    certifications: toLines(payload.certifications ?? ""),
-    awards: toLines(payload.awards ?? ""),
     pronouns: cleanText(payload.pronouns),
     phonetic_name: cleanText(payload.phonetic_name),
-    languages: toLines(payload.languages ?? ""),
-    access_notes: cleanText(payload.access_notes),
+    cta_primary_label: cleanText(payload.cta_primary_label),
+    cta_primary_url: cleanText(payload.cta_primary_url),
+    cta_secondary_label: cleanText(payload.cta_secondary_label),
+    cta_secondary_url: cleanText(payload.cta_secondary_url),
+    career_cta_label: cleanText(payload.career_cta_label),
+    career_cta_url: cleanText(payload.career_cta_url),
   });
 
   if (error) {
     throw new Error(error.message);
   }
 
-  revalidatePath("/");
-  revalidatePath("/contact");
-  revalidatePath("/resume");
-  revalidatePath("/admin/site-profile");
+  revalidateProfile();
+  redirect("/admin/site-profile?status=profile-saved");
+}
 
-  redirect("/admin/site-profile?status=success");
+async function upsertRow<T extends z.ZodTypeAny>(
+  formData: FormData,
+  schema: T,
+  table: string,
+  status: string,
+  mapper: (payload: z.infer<T>) => Record<string, unknown>,
+) {
+  await requireAdminUser();
+  const rawInput: Record<string, unknown> = {
+    id: getString(formData, "id"),
+    title: getString(formData, "title"),
+    description: getString(formData, "description"),
+    icon_slug: getString(formData, "icon_slug"),
+    link_label: getString(formData, "link_label"),
+    link_url: getString(formData, "link_url"),
+    event: getString(formData, "event"),
+    year: getString(formData, "year"),
+    quote: getString(formData, "quote"),
+    attribution: getString(formData, "attribution"),
+    role: getString(formData, "role"),
+    issuer: getString(formData, "issuer"),
+    order_index: getString(formData, "order_index") ?? "0",
+  };
+  const payload = schema.parse(rawInput);
+
+  const admin = createSupabaseAdminClient();
+  const { error } = await admin.from(table).upsert(mapper(payload));
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  revalidateProfile();
+  redirect(`/admin/site-profile?status=${status}`);
+}
+
+async function deleteRow(formData: FormData, table: string, status: string, labelKey = "title") {
+  await requireAdminUser();
+  const id = getString(formData, "id");
+  if (!id) {
+    throw new Error("Missing id");
+  }
+
+  const admin = createSupabaseAdminClient();
+  const { error } = await admin.from(table).delete().eq("id", id);
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  revalidateProfile();
+  const params = new URLSearchParams({ status });
+  const label = getString(formData, labelKey);
+  if (label) params.set("what", label);
+  redirect(`/admin/site-profile?${params.toString()}`);
+}
+
+export async function upsertProfilePillar(formData: FormData) {
+  return upsertRow(
+    formData,
+    pillarSchema,
+    "profile_pillars",
+    "pillar-saved",
+    (payload) => ({
+      id: payload.id,
+      title: payload.title,
+      description: payload.description,
+      icon_slug: cleanText(payload.icon_slug),
+      link_label: cleanText(payload.link_label),
+      link_url: cleanText(payload.link_url),
+      order_index: orderValue(payload.order_index, 0),
+    }),
+  );
+}
+
+export async function deleteProfilePillar(formData: FormData) {
+  return deleteRow(formData, "profile_pillars", "pillar-deleted");
+}
+
+export async function upsertProfileCareerHighlight(formData: FormData) {
+  return upsertRow(
+    formData,
+    careerSchema,
+    "profile_career_highlights",
+    "career-saved",
+    (payload) => ({
+      id: payload.id,
+      title: payload.title,
+      description: payload.description,
+      link_label: cleanText(payload.link_label),
+      link_url: cleanText(payload.link_url),
+      order_index: orderValue(payload.order_index, 0),
+    }),
+  );
+}
+
+export async function deleteProfileCareerHighlight(formData: FormData) {
+  return deleteRow(formData, "profile_career_highlights", "career-deleted");
+}
+
+export async function upsertProfileSpeaking(formData: FormData) {
+  return upsertRow(
+    formData,
+    speakingSchema,
+    "profile_speaking_engagements",
+    "speaking-saved",
+    (payload) => ({
+      id: payload.id,
+      event: payload.event,
+      title: cleanText(payload.title),
+      year: cleanText(payload.year),
+      link_url: cleanText(payload.link_url),
+      order_index: orderValue(payload.order_index, 0),
+    }),
+  );
+}
+
+export async function deleteProfileSpeaking(formData: FormData) {
+  return deleteRow(formData, "profile_speaking_engagements", "speaking-deleted", "event");
+}
+
+export async function upsertProfileRecognition(formData: FormData) {
+  return upsertRow(
+    formData,
+    recognitionSchema,
+    "profile_recognitions",
+    "recognition-saved",
+    (payload) => ({
+      id: payload.id,
+      title: payload.title,
+      issuer: cleanText(payload.issuer),
+      year: cleanText(payload.year),
+      link_url: cleanText(payload.link_url),
+      order_index: orderValue(payload.order_index, 0),
+    }),
+  );
+}
+
+export async function deleteProfileRecognition(formData: FormData) {
+  return deleteRow(formData, "profile_recognitions", "recognition-deleted");
+}
+
+export async function upsertProfileTestimonial(formData: FormData) {
+  return upsertRow(
+    formData,
+    testimonialSchema,
+    "profile_testimonials",
+    "testimonial-saved",
+    (payload) => ({
+      id: payload.id,
+      quote: payload.quote,
+      attribution: payload.attribution,
+      role: cleanText(payload.role),
+      link_url: cleanText(payload.link_url),
+      order_index: orderValue(payload.order_index, 0),
+    }),
+  );
+}
+
+export async function deleteProfileTestimonial(formData: FormData) {
+  return deleteRow(formData, "profile_testimonials", "testimonial-deleted", "attribution");
+}
+
+export async function upsertProfilePersonalEntry(formData: FormData) {
+  return upsertRow(
+    formData,
+    personalSchema,
+    "profile_personal_entries",
+    "personal-saved",
+    (payload) => ({
+      id: payload.id,
+      title: payload.title,
+      description: payload.description,
+      icon_slug: cleanText(payload.icon_slug),
+      order_index: orderValue(payload.order_index, 0),
+    }),
+  );
+}
+
+export async function deleteProfilePersonalEntry(formData: FormData) {
+  return deleteRow(formData, "profile_personal_entries", "personal-deleted");
 }

--- a/app/admin/(dashboard)/site-profile/career-highlights-manager.tsx
+++ b/app/admin/(dashboard)/site-profile/career-highlights-manager.tsx
@@ -42,7 +42,9 @@ export function CareerHighlightsManager({ highlights, status, detail }: Props) {
         <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div>
             <CardTitle>Career highlights</CardTitle>
-            <CardDescription>Condensed timeline entries that back up your expertise claims.</CardDescription>
+            <CardDescription>
+              Condensed timeline entries that back up your expertise claims.
+            </CardDescription>
           </div>
           <Button size="sm" onClick={() => handleOpen()}>
             Add highlight
@@ -51,7 +53,9 @@ export function CareerHighlightsManager({ highlights, status, detail }: Props) {
         {status === "career-saved" ? (
           <p className="text-sm text-emerald-600">Highlight saved.</p>
         ) : status === "career-deleted" ? (
-          <p className="text-sm text-emerald-600">Removed highlight {detail ? `“${detail}”` : ""}.</p>
+          <p className="text-sm text-emerald-600">
+            Removed highlight {detail ? `“${detail}”` : ""}.
+          </p>
         ) : null}
       </CardHeader>
       <CardContent>
@@ -71,8 +75,8 @@ export function CareerHighlightsManager({ highlights, status, detail }: Props) {
                 highlights.map((highlight) => (
                   <tr key={highlight.id} className="border-b last:border-0">
                     <td className="px-3 py-2 font-medium">{highlight.title}</td>
-                    <td className="px-3 py-2 text-muted-foreground">{highlight.description}</td>
-                    <td className="px-3 py-2 break-all">{highlight.link_url ?? "—"}</td>
+                    <td className="text-muted-foreground px-3 py-2">{highlight.description}</td>
+                    <td className="break-all px-3 py-2">{highlight.link_url ?? "—"}</td>
                     <td className="px-3 py-2">{highlight.order_index}</td>
                     <td className="px-3 py-2">
                       <Button size="sm" variant="outline" onClick={() => handleOpen(highlight.id)}>
@@ -83,7 +87,7 @@ export function CareerHighlightsManager({ highlights, status, detail }: Props) {
                 ))
               ) : (
                 <tr>
-                  <td colSpan={5} className="px-3 py-6 text-center text-muted-foreground">
+                  <td colSpan={5} className="text-muted-foreground px-3 py-6 text-center">
                     No highlights yet. Add 3–5 achievements with measurable impact.
                   </td>
                 </tr>
@@ -93,7 +97,11 @@ export function CareerHighlightsManager({ highlights, status, detail }: Props) {
         </div>
       </CardContent>
 
-      <Modal open={open} onClose={handleClose} title={selected ? "Edit highlight" : "Add highlight"}>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        title={selected ? "Edit highlight" : "Add highlight"}
+      >
         <form
           id="career-highlight-form"
           key={selected?.id ?? "create"}
@@ -105,7 +113,12 @@ export function CareerHighlightsManager({ highlights, status, detail }: Props) {
             <label className="text-sm font-medium" htmlFor="highlight-title">
               Title
             </label>
-            <Input id="highlight-title" name="title" defaultValue={selected?.title ?? ""} required />
+            <Input
+              id="highlight-title"
+              name="title"
+              defaultValue={selected?.title ?? ""}
+              required
+            />
           </div>
           <div className="space-y-2">
             <label className="text-sm font-medium" htmlFor="highlight-description">

--- a/app/admin/(dashboard)/site-profile/career-highlights-manager.tsx
+++ b/app/admin/(dashboard)/site-profile/career-highlights-manager.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { Modal } from "@/components/admin/modal";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import type { ProfileCareerHighlight } from "@/lib/supabase/types";
+
+import { deleteProfileCareerHighlight, upsertProfileCareerHighlight } from "./actions";
+
+type Props = {
+  highlights: ProfileCareerHighlight[];
+  status?: string;
+  detail?: string;
+};
+
+export function CareerHighlightsManager({ highlights, status, detail }: Props) {
+  const [open, setOpen] = useState(false);
+  const [selectedId, setSelectedId] = useState<string>("");
+
+  const selected = useMemo(
+    () => highlights.find((highlight) => highlight.id === selectedId) ?? null,
+    [highlights, selectedId],
+  );
+
+  const handleOpen = (id?: string) => {
+    setSelectedId(id ?? "");
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    setSelectedId("");
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <CardTitle>Career highlights</CardTitle>
+            <CardDescription>Condensed timeline entries that back up your expertise claims.</CardDescription>
+          </div>
+          <Button size="sm" onClick={() => handleOpen()}>
+            Add highlight
+          </Button>
+        </div>
+        {status === "career-saved" ? (
+          <p className="text-sm text-emerald-600">Highlight saved.</p>
+        ) : status === "career-deleted" ? (
+          <p className="text-sm text-emerald-600">Removed highlight {detail ? `“${detail}”` : ""}.</p>
+        ) : null}
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-hidden rounded-md border">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-muted/40">
+              <tr className="border-b">
+                <th className="px-3 py-2">Title</th>
+                <th className="px-3 py-2">Description</th>
+                <th className="px-3 py-2">Link</th>
+                <th className="px-3 py-2">Order</th>
+                <th className="px-3 py-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {highlights.length > 0 ? (
+                highlights.map((highlight) => (
+                  <tr key={highlight.id} className="border-b last:border-0">
+                    <td className="px-3 py-2 font-medium">{highlight.title}</td>
+                    <td className="px-3 py-2 text-muted-foreground">{highlight.description}</td>
+                    <td className="px-3 py-2 break-all">{highlight.link_url ?? "—"}</td>
+                    <td className="px-3 py-2">{highlight.order_index}</td>
+                    <td className="px-3 py-2">
+                      <Button size="sm" variant="outline" onClick={() => handleOpen(highlight.id)}>
+                        Edit
+                      </Button>
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={5} className="px-3 py-6 text-center text-muted-foreground">
+                    No highlights yet. Add 3–5 achievements with measurable impact.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+
+      <Modal open={open} onClose={handleClose} title={selected ? "Edit highlight" : "Add highlight"}>
+        <form
+          id="career-highlight-form"
+          key={selected?.id ?? "create"}
+          action={upsertProfileCareerHighlight}
+          className="grid gap-3"
+        >
+          <input type="hidden" name="id" value={selected?.id ?? ""} />
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="highlight-title">
+              Title
+            </label>
+            <Input id="highlight-title" name="title" defaultValue={selected?.title ?? ""} required />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="highlight-description">
+              Description
+            </label>
+            <Textarea
+              id="highlight-description"
+              name="description"
+              rows={3}
+              defaultValue={selected?.description ?? ""}
+              required
+            />
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="highlight-link-label">
+                Link label
+              </label>
+              <Input
+                id="highlight-link-label"
+                name="link_label"
+                defaultValue={selected?.link_label ?? ""}
+                placeholder="Read the case study"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="highlight-link-url">
+                Link URL
+              </label>
+              <Input
+                id="highlight-link-url"
+                name="link_url"
+                defaultValue={selected?.link_url ?? ""}
+                placeholder="/case-studies"
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="highlight-order">
+              Order index
+            </label>
+            <Input
+              id="highlight-order"
+              name="order_index"
+              type="number"
+              defaultValue={selected?.order_index ?? highlights.length}
+              min={0}
+            />
+          </div>
+        </form>
+        <div className="flex items-center justify-between gap-3 pt-4">
+          {selected ? (
+            <form
+              action={deleteProfileCareerHighlight}
+              onSubmit={(event) => {
+                if (!confirm("Delete this highlight?")) event.preventDefault();
+              }}
+            >
+              <input type="hidden" name="id" value={selected.id} />
+              <input type="hidden" name="title" value={selected.title} />
+              <Button variant="destructive" type="submit">
+                Delete
+              </Button>
+            </form>
+          ) : (
+            <span />
+          )}
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button type="submit" form="career-highlight-form">
+              {selected ? "Save" : "Create"}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </Card>
+  );
+}

--- a/app/admin/(dashboard)/site-profile/page.tsx
+++ b/app/admin/(dashboard)/site-profile/page.tsx
@@ -6,9 +6,27 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { getSiteProfile } from "@/lib/supabase/queries";
+import {
+  fetchProfileCareerHighlights,
+  fetchProfilePersonalEntries,
+  fetchProfilePillars,
+  fetchProfileRecognitions,
+  fetchProfileSpeaking,
+  fetchProfileTestimonials,
+  fetchSiteProfile,
+} from "@/lib/admin/queries";
 
 import { upsertSiteProfile } from "./actions";
+import { CareerHighlightsManager } from "./career-highlights-manager";
+import { PersonalEntriesManager } from "./personal-entries-manager";
+import { PillarsManager } from "./pillars-manager";
+import { RecognitionManager } from "./recognition-manager";
+import { SpeakingManager } from "./speaking-manager";
+import { TestimonialsManager } from "./testimonials-manager";
+
+function matchStatus(status: string | undefined, prefix: string) {
+  return status && status.startsWith(prefix) ? status : undefined;
+}
 
 export default async function SiteProfileAdminPage({
   searchParams,
@@ -16,52 +34,113 @@ export default async function SiteProfileAdminPage({
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const sp = await searchParams;
-  const profile = await getSiteProfile();
-  const saved = sp?.status === "success";
+  const status = typeof sp?.status === "string" ? sp.status : undefined;
+  const detail = typeof sp?.what === "string" ? sp.what : undefined;
+
+  const [
+    profile,
+    pillars,
+    highlights,
+    speaking,
+    recognitions,
+    testimonials,
+    personalEntries,
+  ] = await Promise.all([
+    fetchSiteProfile(),
+    fetchProfilePillars(),
+    fetchProfileCareerHighlights(),
+    fetchProfileSpeaking(),
+    fetchProfileRecognitions(),
+    fetchProfileTestimonials(),
+    fetchProfilePersonalEntries(),
+  ]);
+
+  const avatarUrl = profile?.avatar_url || "/profile-placeholder.svg";
+  const profileSaved = status === "profile-saved";
+  const pillarStatus = matchStatus(status, "pillar-");
+  const careerStatus = matchStatus(status, "career-");
+  const speakingStatus = matchStatus(status, "speaking-");
+  const recognitionStatus = matchStatus(status, "recognition-");
+  const testimonialStatus = matchStatus(status, "testimonial-");
+  const personalStatus = matchStatus(status, "personal-");
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       <header className="space-y-1">
-        <h1 className="text-3xl font-semibold">Site Profile</h1>
+        <h1 className="text-3xl font-semibold">Site profile</h1>
         <p className="text-muted-foreground text-sm">
-          Control public profile details like name, headline, summary, avatar, and availability.
+          Design the public profile experience. Update the hero, philosophy, CTAs, and supporting credibility blocks.
         </p>
       </header>
 
-      <div className="grid gap-6 lg:grid-cols-[1fr_1.2fr]">
+      <div className="grid gap-6 xl:grid-cols-[1.15fr_1fr]">
         <Card>
           <CardHeader>
-            <CardTitle>Public preview</CardTitle>
-            <CardDescription>Snapshot of what visitors see on the homepage.</CardDescription>
+            <CardTitle>Profile preview</CardTitle>
+            <CardDescription>Approximation of the hero area rendered on the public /profile page.</CardDescription>
           </CardHeader>
-          <CardContent className="space-y-4 text-sm">
-            <Badge variant="outline">{profile?.hiring_status ?? "Open to opportunities"}</Badge>
-            {profile?.pronouns ? (
-              <Badge variant="secondary" className="uppercase tracking-wide">
-                {profile.pronouns}
-              </Badge>
-            ) : null}
-            <div>
-              <p className="text-lg font-semibold">
-                {profile?.headline ?? "Security-first engineering leader."}
-              </p>
-              <p className="text-muted-foreground mt-2">
-                {profile?.summary ?? "Add a summary to describe your focus."}
-              </p>
+          <CardContent className="space-y-6">
+            <div className="relative overflow-hidden rounded-3xl border bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-6 text-slate-50 shadow-sm">
+              <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+                <div className="space-y-4">
+                  <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-wide text-slate-300">
+                    {profile?.hiring_status ? (
+                      <Badge variant="secondary" className="border-white/10 bg-white/10 font-medium text-white">
+                        {profile.hiring_status}
+                      </Badge>
+                    ) : null}
+                    {profile?.pronouns ? (
+                      <Badge variant="outline" className="border-white/20 bg-white/5 text-white">
+                        {profile.pronouns}
+                      </Badge>
+                    ) : null}
+                    {profile?.phonetic_name ? (
+                      <span className="rounded-full bg-white/5 px-3 py-1 text-[0.7rem] text-slate-200">
+                        Pronounced {profile.phonetic_name}
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="space-y-2">
+                    <p className="text-sm text-slate-300">{profile?.location ?? "Add location or availability"}</p>
+                    <h2 className="text-3xl font-semibold tracking-tight">
+                      {profile?.full_name ?? "Your name"}
+                    </h2>
+                    <p className="text-xl font-medium text-slate-200">
+                      {profile?.headline ?? "Security-first engineering leader."}
+                    </p>
+                    {profile?.subheadline ? (
+                      <p className="text-slate-300">{profile.subheadline}</p>
+                    ) : null}
+                  </div>
+                  {profile?.summary ? (
+                    <p className="text-sm leading-relaxed text-slate-300">{profile.summary}</p>
+                  ) : (
+                    <p className="text-sm italic text-slate-400">
+                      Use the summary to anchor why your perspective matters.
+                    </p>
+                  )}
+                  <div className="flex flex-wrap gap-3 pt-1">
+                    {profile?.cta_primary_label && profile.cta_primary_url ? (
+                      <Button size="sm" variant="secondary" className="bg-white text-slate-900 hover:bg-white/90">
+                        {profile.cta_primary_label}
+                      </Button>
+                    ) : null}
+                    {profile?.cta_secondary_label && profile.cta_secondary_url ? (
+                      <Button size="sm" variant="outline" className="border-white/30 text-white hover:bg-white/10">
+                        {profile.cta_secondary_label}
+                      </Button>
+                    ) : null}
+                  </div>
+                </div>
+                <div className="relative mx-auto h-36 w-36 overflow-hidden rounded-full border border-white/20 bg-white/10 sm:h-40 sm:w-40">
+                  <Image src={avatarUrl} alt={profile?.full_name ?? "Profile"} fill sizes="160px" className="object-cover" />
+                </div>
+              </div>
             </div>
-            {profile?.phonetic_name ? (
-              <p className="text-muted-foreground text-xs">Pronounced: {profile.phonetic_name}</p>
-            ) : null}
-            {/* Highlights removed from profile; hero metrics now derive from featured case studies. */}
-            {profile?.avatar_url ? (
-              <div className="relative mt-4 h-32 w-32 overflow-hidden rounded-full border">
-                <Image
-                  src={profile.avatar_url}
-                  alt={profile.full_name ?? "Profile"}
-                  fill
-                  sizes="128px"
-                  className="object-cover"
-                />
+            {profile?.philosophy ? (
+              <div className="rounded-2xl border bg-muted/40 p-5">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">My philosophy</p>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{profile.philosophy}</p>
               </div>
             ) : null}
           </CardContent>
@@ -70,33 +149,25 @@ export default async function SiteProfileAdminPage({
         <Card>
           <CardHeader>
             <CardTitle>Edit profile</CardTitle>
-            <CardDescription>All fields are optional except the name and headline.</CardDescription>
+            <CardDescription>
+              Craft the hero narrative. Keep full name and headline concise; use the philosophy to add voice.
+            </CardDescription>
           </CardHeader>
           <CardContent>
-            <form action={upsertSiteProfile} className="space-y-4">
+            <form action={upsertSiteProfile} className="space-y-5">
               <input type="hidden" name="id" defaultValue={profile?.id ?? ""} />
               <div className="space-y-2">
                 <label className="text-sm font-medium" htmlFor="full_name">
                   Full name
                 </label>
-                <Input
-                  id="full_name"
-                  name="full_name"
-                  defaultValue={profile?.full_name ?? ""}
-                  required
-                />
+                <Input id="full_name" name="full_name" defaultValue={profile?.full_name ?? ""} required />
               </div>
               <div className="grid gap-4 md:grid-cols-2">
                 <div className="space-y-2">
                   <label className="text-sm font-medium" htmlFor="pronouns">
                     Pronouns
                   </label>
-                  <Input
-                    id="pronouns"
-                    name="pronouns"
-                    defaultValue={profile?.pronouns ?? ""}
-                    placeholder="they/them"
-                  />
+                  <Input id="pronouns" name="pronouns" defaultValue={profile?.pronouns ?? ""} placeholder="they/them" />
                 </div>
                 <div className="space-y-2">
                   <label className="text-sm font-medium" htmlFor="phonetic_name">
@@ -114,32 +185,30 @@ export default async function SiteProfileAdminPage({
                 <label className="text-sm font-medium" htmlFor="headline">
                   Headline
                 </label>
-                <Input
-                  id="headline"
-                  name="headline"
-                  defaultValue={profile?.headline ?? ""}
-                  required
-                />
+                <Input id="headline" name="headline" defaultValue={profile?.headline ?? ""} required />
               </div>
               <div className="space-y-2">
                 <label className="text-sm font-medium" htmlFor="subheadline">
                   Subheadline
                 </label>
-                <Input
-                  id="subheadline"
-                  name="subheadline"
-                  defaultValue={profile?.subheadline ?? ""}
-                />
+                <Input id="subheadline" name="subheadline" defaultValue={profile?.subheadline ?? ""} />
               </div>
               <div className="space-y-2">
                 <label className="text-sm font-medium" htmlFor="summary">
                   Summary
                 </label>
+                <Textarea id="summary" name="summary" rows={3} defaultValue={profile?.summary ?? ""} />
+              </div>
+              <div className="space-y-2">
+                <label className="text-sm font-medium" htmlFor="philosophy">
+                  Philosophy
+                </label>
                 <Textarea
-                  id="summary"
-                  name="summary"
-                  defaultValue={profile?.summary ?? ""}
-                  rows={4}
+                  id="philosophy"
+                  name="philosophy"
+                  rows={3}
+                  placeholder="Share a concise POV that frames your mission."
+                  defaultValue={profile?.philosophy ?? ""}
                 />
               </div>
               <div className="grid gap-4 md:grid-cols-2">
@@ -147,17 +216,13 @@ export default async function SiteProfileAdminPage({
                   <label className="text-sm font-medium" htmlFor="avatar_url">
                     Avatar URL
                   </label>
-                  <Input
-                    id="avatar_url"
-                    name="avatar_url"
-                    defaultValue={profile?.avatar_url ?? ""}
-                  />
+                  <Input id="avatar_url" name="avatar_url" defaultValue={profile?.avatar_url ?? ""} />
                 </div>
                 <div className="space-y-2">
                   <label className="text-sm font-medium" htmlFor="location">
                     Location / availability
                   </label>
-                  <Input id="location" name="location" defaultValue={profile?.location ?? ""} />
+                  <Input id="location" name="location" defaultValue={profile?.location ?? ""} placeholder="Remote-first" />
                 </div>
                 <div className="space-y-2">
                   <label className="text-sm font-medium" htmlFor="hiring_status">
@@ -167,6 +232,7 @@ export default async function SiteProfileAdminPage({
                     id="hiring_status"
                     name="hiring_status"
                     defaultValue={profile?.hiring_status ?? ""}
+                    placeholder="Open to Director-level security roles"
                   />
                 </div>
                 <div className="space-y-2">
@@ -185,111 +251,107 @@ export default async function SiteProfileAdminPage({
                   </select>
                 </div>
               </div>
-              <div className="grid gap-4 md:grid-cols-3">
-                <div className="space-y-2">
-                  <label className="text-sm font-medium" htmlFor="speaking">
-                    Speaking (one per line)
-                  </label>
-                  <Textarea
-                    id="speaking"
-                    name="speaking"
-                    defaultValue={
-                      (profile as unknown as { speaking?: string[] })?.speaking?.join("\n") ?? ""
-                    }
-                    rows={5}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <label className="text-sm font-medium" htmlFor="certifications">
-                    Certifications (one per line)
-                  </label>
-                  <Textarea
-                    id="certifications"
-                    name="certifications"
-                    defaultValue={
-                      (profile as unknown as { certifications?: string[] })?.certifications?.join(
-                        "\n",
-                      ) ?? ""
-                    }
-                    rows={5}
-                  />
-                </div>
-                <div className="space-y-2">
-                  <label className="text-sm font-medium" htmlFor="awards">
-                    Awards (one per line)
-                  </label>
-                  <Textarea
-                    id="awards"
-                    name="awards"
-                    defaultValue={
-                      (profile as unknown as { awards?: string[] })?.awards?.join("\n") ?? ""
-                    }
-                    rows={5}
-                  />
-                </div>
-              </div>
-              {/* Highlights removed; managed via featured case studies. */}
               <div className="grid gap-4 md:grid-cols-2">
                 <div className="space-y-2">
-                  <label className="text-sm font-medium" htmlFor="hobbies">
-                    Hobbies (one per line)
+                  <label className="text-sm font-medium" htmlFor="cta_primary_label">
+                    Primary CTA label
                   </label>
-                  <Textarea
-                    id="hobbies"
-                    name="hobbies"
-                    defaultValue={(profile?.hobbies ?? []).join("\n")}
-                    rows={5}
+                  <Input
+                    id="cta_primary_label"
+                    name="cta_primary_label"
+                    defaultValue={profile?.cta_primary_label ?? ""}
+                    placeholder="Explore my work"
                   />
                 </div>
                 <div className="space-y-2">
-                  <label className="text-sm font-medium" htmlFor="interests">
-                    Special interests (one per line)
+                  <label className="text-sm font-medium" htmlFor="cta_primary_url">
+                    Primary CTA URL
                   </label>
-                  <Textarea
-                    id="interests"
-                    name="interests"
-                    defaultValue={(profile?.interests ?? []).join("\n")}
-                    rows={5}
+                  <Input id="cta_primary_url" name="cta_primary_url" defaultValue={profile?.cta_primary_url ?? ""} />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium" htmlFor="cta_secondary_label">
+                    Secondary CTA label
+                  </label>
+                  <Input
+                    id="cta_secondary_label"
+                    name="cta_secondary_label"
+                    defaultValue={profile?.cta_secondary_label ?? ""}
+                    placeholder="Contact me"
                   />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-sm font-medium" htmlFor="cta_secondary_url">
+                    Secondary CTA URL
+                  </label>
+                  <Input id="cta_secondary_url" name="cta_secondary_url" defaultValue={profile?.cta_secondary_url ?? ""} />
                 </div>
               </div>
               <div className="grid gap-4 md:grid-cols-2">
                 <div className="space-y-2">
-                  <label className="text-sm font-medium" htmlFor="languages">
-                    Languages (one per line)
+                  <label className="text-sm font-medium" htmlFor="career_cta_label">
+                    Career highlights CTA label
                   </label>
-                  <Textarea
-                    id="languages"
-                    name="languages"
-                    defaultValue={(profile?.languages ?? []).join("\n")}
-                    rows={4}
+                  <Input
+                    id="career_cta_label"
+                    name="career_cta_label"
+                    defaultValue={profile?.career_cta_label ?? ""}
+                    placeholder="Read full case studies →"
                   />
                 </div>
                 <div className="space-y-2">
-                  <label className="text-sm font-medium" htmlFor="access_notes">
-                    Collaboration & access notes
+                  <label className="text-sm font-medium" htmlFor="career_cta_url">
+                    Career highlights CTA URL
                   </label>
-                  <Textarea
-                    id="access_notes"
-                    name="access_notes"
-                    defaultValue={profile?.access_notes ?? ""}
-                    rows={4}
-                  />
-                  <p className="text-muted-foreground text-xs">
-                    Optional: share accessibility preferences, scheduling needs, or accommodations.
-                  </p>
+                  <Input id="career_cta_url" name="career_cta_url" defaultValue={profile?.career_cta_url ?? ""} />
                 </div>
               </div>
-              {saved ? <p className="text-sm text-emerald-600">Profile saved.</p> : null}
-              <div className="flex justify-end gap-3">
-                <Button type="submit">Save profile</Button>
-                <Button asChild variant="outline">
-                  <Link href="/">View homepage</Link>
-                </Button>
+              {profileSaved ? <p className="text-sm text-emerald-600">Profile saved.</p> : null}
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="text-muted-foreground text-xs">
+                  Tip: keep updates cohesive—adjust CTAs after adding new case studies.
+                </div>
+                <div className="flex gap-2">
+                  <Button type="button" variant="outline" asChild>
+                    <Link href="/profile">View profile</Link>
+                  </Button>
+                  <Button type="submit">Save profile</Button>
+                </div>
               </div>
             </form>
           </CardContent>
         </Card>
+      </div>
+
+      <div className="space-y-6">
+        <PillarsManager pillars={pillars} status={pillarStatus} detail={pillarStatus ? detail : undefined} />
+        <CareerHighlightsManager
+          highlights={highlights}
+          status={careerStatus}
+          detail={careerStatus ? detail : undefined}
+        />
+        <div className="grid gap-6 lg:grid-cols-2">
+          <SpeakingManager
+            speaking={speaking}
+            status={speakingStatus}
+            detail={speakingStatus ? detail : undefined}
+          />
+          <RecognitionManager
+            recognitions={recognitions}
+            status={recognitionStatus}
+            detail={recognitionStatus ? detail : undefined}
+          />
+        </div>
+        <TestimonialsManager
+          testimonials={testimonials}
+          status={testimonialStatus}
+          detail={testimonialStatus ? detail : undefined}
+        />
+        <PersonalEntriesManager
+          entries={personalEntries}
+          status={personalStatus}
+          detail={personalStatus ? detail : undefined}
+        />
       </div>
     </div>
   );

--- a/app/admin/(dashboard)/site-profile/page.tsx
+++ b/app/admin/(dashboard)/site-profile/page.tsx
@@ -1,7 +1,5 @@
-import Image from "next/image";
 import Link from "next/link";
 
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -37,25 +35,17 @@ export default async function SiteProfileAdminPage({
   const status = typeof sp?.status === "string" ? sp.status : undefined;
   const detail = typeof sp?.what === "string" ? sp.what : undefined;
 
-  const [
-    profile,
-    pillars,
-    highlights,
-    speaking,
-    recognitions,
-    testimonials,
-    personalEntries,
-  ] = await Promise.all([
-    fetchSiteProfile(),
-    fetchProfilePillars(),
-    fetchProfileCareerHighlights(),
-    fetchProfileSpeaking(),
-    fetchProfileRecognitions(),
-    fetchProfileTestimonials(),
-    fetchProfilePersonalEntries(),
-  ]);
+  const [profile, pillars, highlights, speaking, recognitions, testimonials, personalEntries] =
+    await Promise.all([
+      fetchSiteProfile(),
+      fetchProfilePillars(),
+      fetchProfileCareerHighlights(),
+      fetchProfileSpeaking(),
+      fetchProfileRecognitions(),
+      fetchProfileTestimonials(),
+      fetchProfilePersonalEntries(),
+    ]);
 
-  const avatarUrl = profile?.avatar_url || "/profile-placeholder.svg";
   const profileSaved = status === "profile-saved";
   const pillarStatus = matchStatus(status, "pillar-");
   const careerStatus = matchStatus(status, "career-");
@@ -69,88 +59,18 @@ export default async function SiteProfileAdminPage({
       <header className="space-y-1">
         <h1 className="text-3xl font-semibold">Site profile</h1>
         <p className="text-muted-foreground text-sm">
-          Design the public profile experience. Update the hero, philosophy, CTAs, and supporting credibility blocks.
+          Design the public profile experience. Update the hero, philosophy, CTAs, and supporting
+          credibility blocks.
         </p>
       </header>
 
-      <div className="grid gap-6 xl:grid-cols-[1.15fr_1fr]">
-        <Card>
-          <CardHeader>
-            <CardTitle>Profile preview</CardTitle>
-            <CardDescription>Approximation of the hero area rendered on the public /profile page.</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            <div className="relative overflow-hidden rounded-3xl border bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-6 text-slate-50 shadow-sm">
-              <div className="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
-                <div className="space-y-4">
-                  <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-wide text-slate-300">
-                    {profile?.hiring_status ? (
-                      <Badge variant="secondary" className="border-white/10 bg-white/10 font-medium text-white">
-                        {profile.hiring_status}
-                      </Badge>
-                    ) : null}
-                    {profile?.pronouns ? (
-                      <Badge variant="outline" className="border-white/20 bg-white/5 text-white">
-                        {profile.pronouns}
-                      </Badge>
-                    ) : null}
-                    {profile?.phonetic_name ? (
-                      <span className="rounded-full bg-white/5 px-3 py-1 text-[0.7rem] text-slate-200">
-                        Pronounced {profile.phonetic_name}
-                      </span>
-                    ) : null}
-                  </div>
-                  <div className="space-y-2">
-                    <p className="text-sm text-slate-300">{profile?.location ?? "Add location or availability"}</p>
-                    <h2 className="text-3xl font-semibold tracking-tight">
-                      {profile?.full_name ?? "Your name"}
-                    </h2>
-                    <p className="text-xl font-medium text-slate-200">
-                      {profile?.headline ?? "Security-first engineering leader."}
-                    </p>
-                    {profile?.subheadline ? (
-                      <p className="text-slate-300">{profile.subheadline}</p>
-                    ) : null}
-                  </div>
-                  {profile?.summary ? (
-                    <p className="text-sm leading-relaxed text-slate-300">{profile.summary}</p>
-                  ) : (
-                    <p className="text-sm italic text-slate-400">
-                      Use the summary to anchor why your perspective matters.
-                    </p>
-                  )}
-                  <div className="flex flex-wrap gap-3 pt-1">
-                    {profile?.cta_primary_label && profile.cta_primary_url ? (
-                      <Button size="sm" variant="secondary" className="bg-white text-slate-900 hover:bg-white/90">
-                        {profile.cta_primary_label}
-                      </Button>
-                    ) : null}
-                    {profile?.cta_secondary_label && profile.cta_secondary_url ? (
-                      <Button size="sm" variant="outline" className="border-white/30 text-white hover:bg-white/10">
-                        {profile.cta_secondary_label}
-                      </Button>
-                    ) : null}
-                  </div>
-                </div>
-                <div className="relative mx-auto h-36 w-36 overflow-hidden rounded-full border border-white/20 bg-white/10 sm:h-40 sm:w-40">
-                  <Image src={avatarUrl} alt={profile?.full_name ?? "Profile"} fill sizes="160px" className="object-cover" />
-                </div>
-              </div>
-            </div>
-            {profile?.philosophy ? (
-              <div className="rounded-2xl border bg-muted/40 p-5">
-                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">My philosophy</p>
-                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{profile.philosophy}</p>
-              </div>
-            ) : null}
-          </CardContent>
-        </Card>
-
+      <div className="space-y-6">
         <Card>
           <CardHeader>
             <CardTitle>Edit profile</CardTitle>
             <CardDescription>
-              Craft the hero narrative. Keep full name and headline concise; use the philosophy to add voice.
+              Craft the hero narrative. Keep full name and headline concise; use the philosophy to
+              add voice.
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -160,14 +80,24 @@ export default async function SiteProfileAdminPage({
                 <label className="text-sm font-medium" htmlFor="full_name">
                   Full name
                 </label>
-                <Input id="full_name" name="full_name" defaultValue={profile?.full_name ?? ""} required />
+                <Input
+                  id="full_name"
+                  name="full_name"
+                  defaultValue={profile?.full_name ?? ""}
+                  required
+                />
               </div>
               <div className="grid gap-4 md:grid-cols-2">
                 <div className="space-y-2">
                   <label className="text-sm font-medium" htmlFor="pronouns">
                     Pronouns
                   </label>
-                  <Input id="pronouns" name="pronouns" defaultValue={profile?.pronouns ?? ""} placeholder="they/them" />
+                  <Input
+                    id="pronouns"
+                    name="pronouns"
+                    defaultValue={profile?.pronouns ?? ""}
+                    placeholder="they/them"
+                  />
                 </div>
                 <div className="space-y-2">
                   <label className="text-sm font-medium" htmlFor="phonetic_name">
@@ -185,19 +115,33 @@ export default async function SiteProfileAdminPage({
                 <label className="text-sm font-medium" htmlFor="headline">
                   Headline
                 </label>
-                <Input id="headline" name="headline" defaultValue={profile?.headline ?? ""} required />
+                <Input
+                  id="headline"
+                  name="headline"
+                  defaultValue={profile?.headline ?? ""}
+                  required
+                />
               </div>
               <div className="space-y-2">
                 <label className="text-sm font-medium" htmlFor="subheadline">
                   Subheadline
                 </label>
-                <Input id="subheadline" name="subheadline" defaultValue={profile?.subheadline ?? ""} />
+                <Input
+                  id="subheadline"
+                  name="subheadline"
+                  defaultValue={profile?.subheadline ?? ""}
+                />
               </div>
               <div className="space-y-2">
                 <label className="text-sm font-medium" htmlFor="summary">
                   Summary
                 </label>
-                <Textarea id="summary" name="summary" rows={3} defaultValue={profile?.summary ?? ""} />
+                <Textarea
+                  id="summary"
+                  name="summary"
+                  rows={3}
+                  defaultValue={profile?.summary ?? ""}
+                />
               </div>
               <div className="space-y-2">
                 <label className="text-sm font-medium" htmlFor="philosophy">
@@ -216,13 +160,22 @@ export default async function SiteProfileAdminPage({
                   <label className="text-sm font-medium" htmlFor="avatar_url">
                     Avatar URL
                   </label>
-                  <Input id="avatar_url" name="avatar_url" defaultValue={profile?.avatar_url ?? ""} />
+                  <Input
+                    id="avatar_url"
+                    name="avatar_url"
+                    defaultValue={profile?.avatar_url ?? ""}
+                  />
                 </div>
                 <div className="space-y-2">
                   <label className="text-sm font-medium" htmlFor="location">
                     Location / availability
                   </label>
-                  <Input id="location" name="location" defaultValue={profile?.location ?? ""} placeholder="Remote-first" />
+                  <Input
+                    id="location"
+                    name="location"
+                    defaultValue={profile?.location ?? ""}
+                    placeholder="Remote-first"
+                  />
                 </div>
                 <div className="space-y-2">
                   <label className="text-sm font-medium" htmlFor="hiring_status">
@@ -267,7 +220,11 @@ export default async function SiteProfileAdminPage({
                   <label className="text-sm font-medium" htmlFor="cta_primary_url">
                     Primary CTA URL
                   </label>
-                  <Input id="cta_primary_url" name="cta_primary_url" defaultValue={profile?.cta_primary_url ?? ""} />
+                  <Input
+                    id="cta_primary_url"
+                    name="cta_primary_url"
+                    defaultValue={profile?.cta_primary_url ?? ""}
+                  />
                 </div>
                 <div className="space-y-2">
                   <label className="text-sm font-medium" htmlFor="cta_secondary_label">
@@ -284,7 +241,11 @@ export default async function SiteProfileAdminPage({
                   <label className="text-sm font-medium" htmlFor="cta_secondary_url">
                     Secondary CTA URL
                   </label>
-                  <Input id="cta_secondary_url" name="cta_secondary_url" defaultValue={profile?.cta_secondary_url ?? ""} />
+                  <Input
+                    id="cta_secondary_url"
+                    name="cta_secondary_url"
+                    defaultValue={profile?.cta_secondary_url ?? ""}
+                  />
                 </div>
               </div>
               <div className="grid gap-4 md:grid-cols-2">
@@ -303,7 +264,11 @@ export default async function SiteProfileAdminPage({
                   <label className="text-sm font-medium" htmlFor="career_cta_url">
                     Career highlights CTA URL
                   </label>
-                  <Input id="career_cta_url" name="career_cta_url" defaultValue={profile?.career_cta_url ?? ""} />
+                  <Input
+                    id="career_cta_url"
+                    name="career_cta_url"
+                    defaultValue={profile?.career_cta_url ?? ""}
+                  />
                 </div>
               </div>
               {profileSaved ? <p className="text-sm text-emerald-600">Profile saved.</p> : null}
@@ -324,7 +289,11 @@ export default async function SiteProfileAdminPage({
       </div>
 
       <div className="space-y-6">
-        <PillarsManager pillars={pillars} status={pillarStatus} detail={pillarStatus ? detail : undefined} />
+        <PillarsManager
+          pillars={pillars}
+          status={pillarStatus}
+          detail={pillarStatus ? detail : undefined}
+        />
         <CareerHighlightsManager
           highlights={highlights}
           status={careerStatus}

--- a/app/admin/(dashboard)/site-profile/personal-entries-manager.tsx
+++ b/app/admin/(dashboard)/site-profile/personal-entries-manager.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { Modal } from "@/components/admin/modal";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import type { ProfilePersonalEntry } from "@/lib/supabase/types";
+
+import { deleteProfilePersonalEntry, upsertProfilePersonalEntry } from "./actions";
+
+type Props = {
+  entries: ProfilePersonalEntry[];
+  status?: string;
+  detail?: string;
+};
+
+export function PersonalEntriesManager({ entries, status, detail }: Props) {
+  const [open, setOpen] = useState(false);
+  const [selectedId, setSelectedId] = useState<string>("");
+
+  const selected = useMemo(
+    () => entries.find((entry) => entry.id === selectedId) ?? null,
+    [entries, selectedId],
+  );
+
+  const handleOpen = (id?: string) => {
+    setSelectedId(id ?? "");
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    setSelectedId("");
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <CardTitle>Beyond security</CardTitle>
+            <CardDescription>Personal interests, languages, and collaboration notes that humanize the profile.</CardDescription>
+          </div>
+          <Button size="sm" onClick={() => handleOpen()}>
+            Add entry
+          </Button>
+        </div>
+        {status === "personal-saved" ? (
+          <p className="text-sm text-emerald-600">Entry saved.</p>
+        ) : status === "personal-deleted" ? (
+          <p className="text-sm text-emerald-600">Removed entry {detail ? `“${detail}”` : ""}.</p>
+        ) : null}
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-hidden rounded-md border">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-muted/40">
+              <tr className="border-b">
+                <th className="px-3 py-2">Title</th>
+                <th className="px-3 py-2">Description</th>
+                <th className="px-3 py-2">Icon</th>
+                <th className="px-3 py-2">Order</th>
+                <th className="px-3 py-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.length > 0 ? (
+                entries.map((entry) => (
+                  <tr key={entry.id} className="border-b last:border-0">
+                    <td className="px-3 py-2 font-medium">{entry.title}</td>
+                    <td className="px-3 py-2 text-muted-foreground">{entry.description}</td>
+                    <td className="px-3 py-2">{entry.icon_slug ?? "—"}</td>
+                    <td className="px-3 py-2">{entry.order_index}</td>
+                    <td className="px-3 py-2">
+                      <Button size="sm" variant="outline" onClick={() => handleOpen(entry.id)}>
+                        Edit
+                      </Button>
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={5} className="px-3 py-6 text-center text-muted-foreground">
+                    No entries yet. Add 3–4 cards such as interests, hobbies, languages, or collaboration style.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+
+      <Modal open={open} onClose={handleClose} title={selected ? "Edit entry" : "Add entry"}>
+        <form id="personal-entry-form" key={selected?.id ?? "create"} action={upsertProfilePersonalEntry} className="grid gap-3">
+          <input type="hidden" name="id" value={selected?.id ?? ""} />
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="personal-entry-title">
+              Title
+            </label>
+            <Input id="personal-entry-title" name="title" defaultValue={selected?.title ?? ""} required />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="personal-entry-description">
+              Description
+            </label>
+            <Textarea
+              id="personal-entry-description"
+              name="description"
+              rows={3}
+              defaultValue={selected?.description ?? ""}
+              required
+            />
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="personal-entry-icon">
+                Icon slug
+              </label>
+              <Input
+                id="personal-entry-icon"
+                name="icon_slug"
+                defaultValue={selected?.icon_slug ?? ""}
+                placeholder="homeassistant, strava, slack"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="personal-entry-order">
+                Order index
+              </label>
+              <Input
+                id="personal-entry-order"
+                name="order_index"
+                type="number"
+                defaultValue={selected?.order_index ?? entries.length}
+                min={0}
+              />
+            </div>
+          </div>
+        </form>
+        <div className="flex items-center justify-between gap-3 pt-4">
+          {selected ? (
+            <form
+              action={deleteProfilePersonalEntry}
+              onSubmit={(event) => {
+                if (!confirm("Delete this entry?")) event.preventDefault();
+              }}
+            >
+              <input type="hidden" name="id" value={selected.id} />
+              <input type="hidden" name="title" value={selected.title} />
+              <Button variant="destructive" type="submit">
+                Delete
+              </Button>
+            </form>
+          ) : (
+            <span />
+          )}
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button type="submit" form="personal-entry-form">
+              {selected ? "Save" : "Create"}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </Card>
+  );
+}

--- a/app/admin/(dashboard)/site-profile/personal-entries-manager.tsx
+++ b/app/admin/(dashboard)/site-profile/personal-entries-manager.tsx
@@ -42,7 +42,9 @@ export function PersonalEntriesManager({ entries, status, detail }: Props) {
         <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div>
             <CardTitle>Beyond security</CardTitle>
-            <CardDescription>Personal interests, languages, and collaboration notes that humanize the profile.</CardDescription>
+            <CardDescription>
+              Personal interests, languages, and collaboration notes that humanize the profile.
+            </CardDescription>
           </div>
           <Button size="sm" onClick={() => handleOpen()}>
             Add entry
@@ -71,7 +73,7 @@ export function PersonalEntriesManager({ entries, status, detail }: Props) {
                 entries.map((entry) => (
                   <tr key={entry.id} className="border-b last:border-0">
                     <td className="px-3 py-2 font-medium">{entry.title}</td>
-                    <td className="px-3 py-2 text-muted-foreground">{entry.description}</td>
+                    <td className="text-muted-foreground px-3 py-2">{entry.description}</td>
                     <td className="px-3 py-2">{entry.icon_slug ?? "—"}</td>
                     <td className="px-3 py-2">{entry.order_index}</td>
                     <td className="px-3 py-2">
@@ -83,8 +85,9 @@ export function PersonalEntriesManager({ entries, status, detail }: Props) {
                 ))
               ) : (
                 <tr>
-                  <td colSpan={5} className="px-3 py-6 text-center text-muted-foreground">
-                    No entries yet. Add 3–4 cards such as interests, hobbies, languages, or collaboration style.
+                  <td colSpan={5} className="text-muted-foreground px-3 py-6 text-center">
+                    No entries yet. Add 3–4 cards such as interests, hobbies, languages, or
+                    collaboration style.
                   </td>
                 </tr>
               )}
@@ -94,13 +97,23 @@ export function PersonalEntriesManager({ entries, status, detail }: Props) {
       </CardContent>
 
       <Modal open={open} onClose={handleClose} title={selected ? "Edit entry" : "Add entry"}>
-        <form id="personal-entry-form" key={selected?.id ?? "create"} action={upsertProfilePersonalEntry} className="grid gap-3">
+        <form
+          id="personal-entry-form"
+          key={selected?.id ?? "create"}
+          action={upsertProfilePersonalEntry}
+          className="grid gap-3"
+        >
           <input type="hidden" name="id" value={selected?.id ?? ""} />
           <div className="space-y-2">
             <label className="text-sm font-medium" htmlFor="personal-entry-title">
               Title
             </label>
-            <Input id="personal-entry-title" name="title" defaultValue={selected?.title ?? ""} required />
+            <Input
+              id="personal-entry-title"
+              name="title"
+              defaultValue={selected?.title ?? ""}
+              required
+            />
           </div>
           <div className="space-y-2">
             <label className="text-sm font-medium" htmlFor="personal-entry-description">

--- a/app/admin/(dashboard)/site-profile/pillars-manager.tsx
+++ b/app/admin/(dashboard)/site-profile/pillars-manager.tsx
@@ -21,7 +21,10 @@ export function PillarsManager({ pillars, status, detail }: Props) {
   const [open, setOpen] = useState(false);
   const [selectedId, setSelectedId] = useState<string>("");
 
-  const selected = useMemo(() => pillars.find((pillar) => pillar.id === selectedId) ?? null, [pillars, selectedId]);
+  const selected = useMemo(
+    () => pillars.find((pillar) => pillar.id === selectedId) ?? null,
+    [pillars, selectedId],
+  );
 
   const handleOpen = (id?: string) => {
     setSelectedId(id ?? "");
@@ -40,7 +43,8 @@ export function PillarsManager({ pillars, status, detail }: Props) {
           <div>
             <CardTitle>Core expertise pillars</CardTitle>
             <CardDescription>
-              Curate the domains highlighted on the public profile hero. Icons reference simple-icons slugs.
+              Curate the domains highlighted on the public profile hero. Icons reference
+              simple-icons slugs.
             </CardDescription>
           </div>
           <Button size="sm" onClick={() => handleOpen()}>
@@ -71,9 +75,9 @@ export function PillarsManager({ pillars, status, detail }: Props) {
                 pillars.map((pillar) => (
                   <tr key={pillar.id} className="border-b last:border-0">
                     <td className="px-3 py-2 font-medium">{pillar.title}</td>
-                    <td className="px-3 py-2 text-muted-foreground">{pillar.description}</td>
+                    <td className="text-muted-foreground px-3 py-2">{pillar.description}</td>
                     <td className="px-3 py-2">{pillar.icon_slug ?? "—"}</td>
-                    <td className="px-3 py-2 break-all">{pillar.link_url ?? "—"}</td>
+                    <td className="break-all px-3 py-2">{pillar.link_url ?? "—"}</td>
                     <td className="px-3 py-2">{pillar.order_index}</td>
                     <td className="px-3 py-2">
                       <Button size="sm" variant="outline" onClick={() => handleOpen(pillar.id)}>
@@ -84,7 +88,7 @@ export function PillarsManager({ pillars, status, detail }: Props) {
                 ))
               ) : (
                 <tr>
-                  <td colSpan={6} className="px-3 py-6 text-center text-muted-foreground">
+                  <td colSpan={6} className="text-muted-foreground px-3 py-6 text-center">
                     No pillars yet. Add 3–4 pillars that represent your focus areas.
                   </td>
                 </tr>

--- a/app/admin/(dashboard)/site-profile/pillars-manager.tsx
+++ b/app/admin/(dashboard)/site-profile/pillars-manager.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { Modal } from "@/components/admin/modal";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import type { ProfilePillar } from "@/lib/supabase/types";
+
+import { deleteProfilePillar, upsertProfilePillar } from "./actions";
+
+type Props = {
+  pillars: ProfilePillar[];
+  status?: string;
+  detail?: string;
+};
+
+export function PillarsManager({ pillars, status, detail }: Props) {
+  const [open, setOpen] = useState(false);
+  const [selectedId, setSelectedId] = useState<string>("");
+
+  const selected = useMemo(() => pillars.find((pillar) => pillar.id === selectedId) ?? null, [pillars, selectedId]);
+
+  const handleOpen = (id?: string) => {
+    setSelectedId(id ?? "");
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    setSelectedId("");
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <CardTitle>Core expertise pillars</CardTitle>
+            <CardDescription>
+              Curate the domains highlighted on the public profile hero. Icons reference simple-icons slugs.
+            </CardDescription>
+          </div>
+          <Button size="sm" onClick={() => handleOpen()}>
+            Add pillar
+          </Button>
+        </div>
+        {status === "pillar-saved" ? (
+          <p className="text-sm text-emerald-600">Pillar saved.</p>
+        ) : status === "pillar-deleted" ? (
+          <p className="text-sm text-emerald-600">Removed pillar {detail ? `“${detail}”` : ""}.</p>
+        ) : null}
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-hidden rounded-md border">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-muted/40">
+              <tr className="border-b">
+                <th className="px-3 py-2">Title</th>
+                <th className="px-3 py-2">Description</th>
+                <th className="px-3 py-2">Icon</th>
+                <th className="px-3 py-2">Link</th>
+                <th className="px-3 py-2">Order</th>
+                <th className="px-3 py-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pillars.length > 0 ? (
+                pillars.map((pillar) => (
+                  <tr key={pillar.id} className="border-b last:border-0">
+                    <td className="px-3 py-2 font-medium">{pillar.title}</td>
+                    <td className="px-3 py-2 text-muted-foreground">{pillar.description}</td>
+                    <td className="px-3 py-2">{pillar.icon_slug ?? "—"}</td>
+                    <td className="px-3 py-2 break-all">{pillar.link_url ?? "—"}</td>
+                    <td className="px-3 py-2">{pillar.order_index}</td>
+                    <td className="px-3 py-2">
+                      <Button size="sm" variant="outline" onClick={() => handleOpen(pillar.id)}>
+                        Edit
+                      </Button>
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={6} className="px-3 py-6 text-center text-muted-foreground">
+                    No pillars yet. Add 3–4 pillars that represent your focus areas.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+
+      <Modal open={open} onClose={handleClose} title={selected ? "Edit pillar" : "Add pillar"}>
+        <form
+          id="pillar-form"
+          key={selected?.id ?? "create"}
+          action={upsertProfilePillar}
+          className="grid gap-3"
+        >
+          <input type="hidden" name="id" value={selected?.id ?? ""} />
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="pillar-title">
+              Title
+            </label>
+            <Input id="pillar-title" name="title" defaultValue={selected?.title ?? ""} required />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="pillar-description">
+              Description
+            </label>
+            <Textarea
+              id="pillar-description"
+              name="description"
+              rows={3}
+              defaultValue={selected?.description ?? ""}
+              required
+            />
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="pillar-icon">
+                Icon slug
+              </label>
+              <Input
+                id="pillar-icon"
+                name="icon_slug"
+                defaultValue={selected?.icon_slug ?? ""}
+                placeholder="openai, githubactions"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="pillar-order">
+                Order index
+              </label>
+              <Input
+                id="pillar-order"
+                name="order_index"
+                type="number"
+                defaultValue={selected?.order_index ?? pillars.length}
+                min={0}
+              />
+            </div>
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="pillar-link-label">
+                Link label
+              </label>
+              <Input
+                id="pillar-link-label"
+                name="link_label"
+                defaultValue={selected?.link_label ?? ""}
+                placeholder="View AI security work"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="pillar-link-url">
+                Link URL
+              </label>
+              <Input
+                id="pillar-link-url"
+                name="link_url"
+                defaultValue={selected?.link_url ?? ""}
+                placeholder="/portfolio?tag=ai-security"
+              />
+            </div>
+          </div>
+        </form>
+        <div className="flex items-center justify-between gap-3 pt-4">
+          {selected ? (
+            <form
+              action={deleteProfilePillar}
+              onSubmit={(event) => {
+                if (!confirm("Delete this pillar?")) event.preventDefault();
+              }}
+            >
+              <input type="hidden" name="id" value={selected.id} />
+              <input type="hidden" name="title" value={selected.title} />
+              <Button variant="destructive" type="submit">
+                Delete
+              </Button>
+            </form>
+          ) : (
+            <span />
+          )}
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button type="submit" form="pillar-form">
+              {selected ? "Save" : "Create"}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </Card>
+  );
+}

--- a/app/admin/(dashboard)/site-profile/recognition-manager.tsx
+++ b/app/admin/(dashboard)/site-profile/recognition-manager.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { Modal } from "@/components/admin/modal";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import type { ProfileRecognition } from "@/lib/supabase/types";
+
+import { deleteProfileRecognition, upsertProfileRecognition } from "./actions";
+
+type Props = {
+  recognitions: ProfileRecognition[];
+  status?: string;
+  detail?: string;
+};
+
+export function RecognitionManager({ recognitions, status, detail }: Props) {
+  const [open, setOpen] = useState(false);
+  const [selectedId, setSelectedId] = useState<string>("");
+
+  const selected = useMemo(
+    () => recognitions.find((item) => item.id === selectedId) ?? null,
+    [recognitions, selectedId],
+  );
+
+  const handleOpen = (id?: string) => {
+    setSelectedId(id ?? "");
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    setSelectedId("");
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <CardTitle>Recognition</CardTitle>
+            <CardDescription>Certifications, awards, and features that add third-party credibility.</CardDescription>
+          </div>
+          <Button size="sm" onClick={() => handleOpen()}>
+            Add recognition
+          </Button>
+        </div>
+        {status === "recognition-saved" ? (
+          <p className="text-sm text-emerald-600">Recognition saved.</p>
+        ) : status === "recognition-deleted" ? (
+          <p className="text-sm text-emerald-600">Removed {detail ? `“${detail}”` : "recognition"}.</p>
+        ) : null}
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-hidden rounded-md border">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-muted/40">
+              <tr className="border-b">
+                <th className="px-3 py-2">Title</th>
+                <th className="px-3 py-2">Issuer</th>
+                <th className="px-3 py-2">Year</th>
+                <th className="px-3 py-2">Link</th>
+                <th className="px-3 py-2">Order</th>
+                <th className="px-3 py-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {recognitions.length > 0 ? (
+                recognitions.map((item) => (
+                  <tr key={item.id} className="border-b last:border-0">
+                    <td className="px-3 py-2 font-medium">{item.title}</td>
+                    <td className="px-3 py-2 text-muted-foreground">{item.issuer ?? "—"}</td>
+                    <td className="px-3 py-2">{item.year ?? "—"}</td>
+                    <td className="px-3 py-2 break-all">{item.link_url ?? "—"}</td>
+                    <td className="px-3 py-2">{item.order_index}</td>
+                    <td className="px-3 py-2">
+                      <Button size="sm" variant="outline" onClick={() => handleOpen(item.id)}>
+                        Edit
+                      </Button>
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={6} className="px-3 py-6 text-center text-muted-foreground">
+                    No recognition entries yet. Add 2–4 credentials or awards.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+
+      <Modal open={open} onClose={handleClose} title={selected ? "Edit recognition" : "Add recognition"}>
+        <form id="recognition-form" key={selected?.id ?? "create"} action={upsertProfileRecognition} className="grid gap-3">
+          <input type="hidden" name="id" value={selected?.id ?? ""} />
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="recognition-title">
+              Title
+            </label>
+            <Input id="recognition-title" name="title" defaultValue={selected?.title ?? ""} required />
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="recognition-issuer">
+                Issuer
+              </label>
+              <Input id="recognition-issuer" name="issuer" defaultValue={selected?.issuer ?? ""} placeholder="ISC²" />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="recognition-year">
+                Year
+              </label>
+              <Input id="recognition-year" name="year" defaultValue={selected?.year ?? ""} placeholder="2024" />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="recognition-link">
+              Link URL
+            </label>
+            <Input
+              id="recognition-link"
+              name="link_url"
+              defaultValue={selected?.link_url ?? ""}
+              placeholder="https://example.com/credential"
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="recognition-order">
+              Order index
+            </label>
+            <Input
+              id="recognition-order"
+              name="order_index"
+              type="number"
+              defaultValue={selected?.order_index ?? recognitions.length}
+              min={0}
+            />
+          </div>
+        </form>
+        <div className="flex items-center justify-between gap-3 pt-4">
+          {selected ? (
+            <form
+              action={deleteProfileRecognition}
+              onSubmit={(event) => {
+                if (!confirm("Delete this recognition?")) event.preventDefault();
+              }}
+            >
+              <input type="hidden" name="id" value={selected.id} />
+              <input type="hidden" name="title" value={selected.title} />
+              <Button variant="destructive" type="submit">
+                Delete
+              </Button>
+            </form>
+          ) : (
+            <span />
+          )}
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button type="submit" form="recognition-form">
+              {selected ? "Save" : "Create"}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </Card>
+  );
+}

--- a/app/admin/(dashboard)/site-profile/recognition-manager.tsx
+++ b/app/admin/(dashboard)/site-profile/recognition-manager.tsx
@@ -41,7 +41,9 @@ export function RecognitionManager({ recognitions, status, detail }: Props) {
         <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div>
             <CardTitle>Recognition</CardTitle>
-            <CardDescription>Certifications, awards, and features that add third-party credibility.</CardDescription>
+            <CardDescription>
+              Certifications, awards, and features that add third-party credibility.
+            </CardDescription>
           </div>
           <Button size="sm" onClick={() => handleOpen()}>
             Add recognition
@@ -50,7 +52,9 @@ export function RecognitionManager({ recognitions, status, detail }: Props) {
         {status === "recognition-saved" ? (
           <p className="text-sm text-emerald-600">Recognition saved.</p>
         ) : status === "recognition-deleted" ? (
-          <p className="text-sm text-emerald-600">Removed {detail ? `“${detail}”` : "recognition"}.</p>
+          <p className="text-sm text-emerald-600">
+            Removed {detail ? `“${detail}”` : "recognition"}.
+          </p>
         ) : null}
       </CardHeader>
       <CardContent>
@@ -71,9 +75,9 @@ export function RecognitionManager({ recognitions, status, detail }: Props) {
                 recognitions.map((item) => (
                   <tr key={item.id} className="border-b last:border-0">
                     <td className="px-3 py-2 font-medium">{item.title}</td>
-                    <td className="px-3 py-2 text-muted-foreground">{item.issuer ?? "—"}</td>
+                    <td className="text-muted-foreground px-3 py-2">{item.issuer ?? "—"}</td>
                     <td className="px-3 py-2">{item.year ?? "—"}</td>
-                    <td className="px-3 py-2 break-all">{item.link_url ?? "—"}</td>
+                    <td className="break-all px-3 py-2">{item.link_url ?? "—"}</td>
                     <td className="px-3 py-2">{item.order_index}</td>
                     <td className="px-3 py-2">
                       <Button size="sm" variant="outline" onClick={() => handleOpen(item.id)}>
@@ -84,7 +88,7 @@ export function RecognitionManager({ recognitions, status, detail }: Props) {
                 ))
               ) : (
                 <tr>
-                  <td colSpan={6} className="px-3 py-6 text-center text-muted-foreground">
+                  <td colSpan={6} className="text-muted-foreground px-3 py-6 text-center">
                     No recognition entries yet. Add 2–4 credentials or awards.
                   </td>
                 </tr>
@@ -94,27 +98,51 @@ export function RecognitionManager({ recognitions, status, detail }: Props) {
         </div>
       </CardContent>
 
-      <Modal open={open} onClose={handleClose} title={selected ? "Edit recognition" : "Add recognition"}>
-        <form id="recognition-form" key={selected?.id ?? "create"} action={upsertProfileRecognition} className="grid gap-3">
+      <Modal
+        open={open}
+        onClose={handleClose}
+        title={selected ? "Edit recognition" : "Add recognition"}
+      >
+        <form
+          id="recognition-form"
+          key={selected?.id ?? "create"}
+          action={upsertProfileRecognition}
+          className="grid gap-3"
+        >
           <input type="hidden" name="id" value={selected?.id ?? ""} />
           <div className="space-y-2">
             <label className="text-sm font-medium" htmlFor="recognition-title">
               Title
             </label>
-            <Input id="recognition-title" name="title" defaultValue={selected?.title ?? ""} required />
+            <Input
+              id="recognition-title"
+              name="title"
+              defaultValue={selected?.title ?? ""}
+              required
+            />
           </div>
           <div className="grid gap-3 md:grid-cols-2">
             <div className="space-y-2">
               <label className="text-sm font-medium" htmlFor="recognition-issuer">
                 Issuer
               </label>
-              <Input id="recognition-issuer" name="issuer" defaultValue={selected?.issuer ?? ""} placeholder="ISC²" />
+              <Input
+                id="recognition-issuer"
+                name="issuer"
+                defaultValue={selected?.issuer ?? ""}
+                placeholder="ISC²"
+              />
             </div>
             <div className="space-y-2">
               <label className="text-sm font-medium" htmlFor="recognition-year">
                 Year
               </label>
-              <Input id="recognition-year" name="year" defaultValue={selected?.year ?? ""} placeholder="2024" />
+              <Input
+                id="recognition-year"
+                name="year"
+                defaultValue={selected?.year ?? ""}
+                placeholder="2024"
+              />
             </div>
           </div>
           <div className="space-y-2">

--- a/app/admin/(dashboard)/site-profile/speaking-manager.tsx
+++ b/app/admin/(dashboard)/site-profile/speaking-manager.tsx
@@ -41,7 +41,9 @@ export function SpeakingManager({ speaking, status, detail }: Props) {
         <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div>
             <CardTitle>Speaking engagements</CardTitle>
-            <CardDescription>Workshops, conferences, and podcasts that reinforce external credibility.</CardDescription>
+            <CardDescription>
+              Workshops, conferences, and podcasts that reinforce external credibility.
+            </CardDescription>
           </div>
           <Button size="sm" onClick={() => handleOpen()}>
             Add engagement
@@ -50,7 +52,9 @@ export function SpeakingManager({ speaking, status, detail }: Props) {
         {status === "speaking-saved" ? (
           <p className="text-sm text-emerald-600">Engagement saved.</p>
         ) : status === "speaking-deleted" ? (
-          <p className="text-sm text-emerald-600">Removed engagement {detail ? `“${detail}”` : ""}.</p>
+          <p className="text-sm text-emerald-600">
+            Removed engagement {detail ? `“${detail}”` : ""}.
+          </p>
         ) : null}
       </CardHeader>
       <CardContent>
@@ -71,9 +75,9 @@ export function SpeakingManager({ speaking, status, detail }: Props) {
                 speaking.map((entry) => (
                   <tr key={entry.id} className="border-b last:border-0">
                     <td className="px-3 py-2 font-medium">{entry.event}</td>
-                    <td className="px-3 py-2 text-muted-foreground">{entry.title ?? "—"}</td>
+                    <td className="text-muted-foreground px-3 py-2">{entry.title ?? "—"}</td>
                     <td className="px-3 py-2">{entry.year ?? "—"}</td>
-                    <td className="px-3 py-2 break-all">{entry.link_url ?? "—"}</td>
+                    <td className="break-all px-3 py-2">{entry.link_url ?? "—"}</td>
                     <td className="px-3 py-2">{entry.order_index}</td>
                     <td className="px-3 py-2">
                       <Button size="sm" variant="outline" onClick={() => handleOpen(entry.id)}>
@@ -84,7 +88,7 @@ export function SpeakingManager({ speaking, status, detail }: Props) {
                 ))
               ) : (
                 <tr>
-                  <td colSpan={6} className="px-3 py-6 text-center text-muted-foreground">
+                  <td colSpan={6} className="text-muted-foreground px-3 py-6 text-center">
                     No engagements logged. Capture high-signal talks and workshops.
                   </td>
                 </tr>
@@ -94,8 +98,17 @@ export function SpeakingManager({ speaking, status, detail }: Props) {
         </div>
       </CardContent>
 
-      <Modal open={open} onClose={handleClose} title={selected ? "Edit engagement" : "Add engagement"}>
-        <form id="speaking-form" key={selected?.id ?? "create"} action={upsertProfileSpeaking} className="grid gap-3">
+      <Modal
+        open={open}
+        onClose={handleClose}
+        title={selected ? "Edit engagement" : "Add engagement"}
+      >
+        <form
+          id="speaking-form"
+          key={selected?.id ?? "create"}
+          action={upsertProfileSpeaking}
+          className="grid gap-3"
+        >
           <input type="hidden" name="id" value={selected?.id ?? ""} />
           <div className="space-y-2">
             <label className="text-sm font-medium" htmlFor="speaking-event">
@@ -119,7 +132,12 @@ export function SpeakingManager({ speaking, status, detail }: Props) {
               <label className="text-sm font-medium" htmlFor="speaking-year">
                 Year
               </label>
-              <Input id="speaking-year" name="year" defaultValue={selected?.year ?? ""} placeholder="2024" />
+              <Input
+                id="speaking-year"
+                name="year"
+                defaultValue={selected?.year ?? ""}
+                placeholder="2024"
+              />
             </div>
           </div>
           <div className="space-y-2">

--- a/app/admin/(dashboard)/site-profile/speaking-manager.tsx
+++ b/app/admin/(dashboard)/site-profile/speaking-manager.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { Modal } from "@/components/admin/modal";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import type { ProfileSpeakingEngagement } from "@/lib/supabase/types";
+
+import { deleteProfileSpeaking, upsertProfileSpeaking } from "./actions";
+
+type Props = {
+  speaking: ProfileSpeakingEngagement[];
+  status?: string;
+  detail?: string;
+};
+
+export function SpeakingManager({ speaking, status, detail }: Props) {
+  const [open, setOpen] = useState(false);
+  const [selectedId, setSelectedId] = useState<string>("");
+
+  const selected = useMemo(
+    () => speaking.find((entry) => entry.id === selectedId) ?? null,
+    [speaking, selectedId],
+  );
+
+  const handleOpen = (id?: string) => {
+    setSelectedId(id ?? "");
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    setSelectedId("");
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <CardTitle>Speaking engagements</CardTitle>
+            <CardDescription>Workshops, conferences, and podcasts that reinforce external credibility.</CardDescription>
+          </div>
+          <Button size="sm" onClick={() => handleOpen()}>
+            Add engagement
+          </Button>
+        </div>
+        {status === "speaking-saved" ? (
+          <p className="text-sm text-emerald-600">Engagement saved.</p>
+        ) : status === "speaking-deleted" ? (
+          <p className="text-sm text-emerald-600">Removed engagement {detail ? `“${detail}”` : ""}.</p>
+        ) : null}
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-hidden rounded-md border">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-muted/40">
+              <tr className="border-b">
+                <th className="px-3 py-2">Event</th>
+                <th className="px-3 py-2">Talk / Topic</th>
+                <th className="px-3 py-2">Year</th>
+                <th className="px-3 py-2">Link</th>
+                <th className="px-3 py-2">Order</th>
+                <th className="px-3 py-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {speaking.length > 0 ? (
+                speaking.map((entry) => (
+                  <tr key={entry.id} className="border-b last:border-0">
+                    <td className="px-3 py-2 font-medium">{entry.event}</td>
+                    <td className="px-3 py-2 text-muted-foreground">{entry.title ?? "—"}</td>
+                    <td className="px-3 py-2">{entry.year ?? "—"}</td>
+                    <td className="px-3 py-2 break-all">{entry.link_url ?? "—"}</td>
+                    <td className="px-3 py-2">{entry.order_index}</td>
+                    <td className="px-3 py-2">
+                      <Button size="sm" variant="outline" onClick={() => handleOpen(entry.id)}>
+                        Edit
+                      </Button>
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={6} className="px-3 py-6 text-center text-muted-foreground">
+                    No engagements logged. Capture high-signal talks and workshops.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+
+      <Modal open={open} onClose={handleClose} title={selected ? "Edit engagement" : "Add engagement"}>
+        <form id="speaking-form" key={selected?.id ?? "create"} action={upsertProfileSpeaking} className="grid gap-3">
+          <input type="hidden" name="id" value={selected?.id ?? ""} />
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="speaking-event">
+              Event
+            </label>
+            <Input id="speaking-event" name="event" defaultValue={selected?.event ?? ""} required />
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="speaking-title">
+                Talk title / topic
+              </label>
+              <Input
+                id="speaking-title"
+                name="title"
+                defaultValue={selected?.title ?? ""}
+                placeholder="SOC automation strategies"
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="speaking-year">
+                Year
+              </label>
+              <Input id="speaking-year" name="year" defaultValue={selected?.year ?? ""} placeholder="2024" />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="speaking-link">
+              Link URL
+            </label>
+            <Input
+              id="speaking-link"
+              name="link_url"
+              defaultValue={selected?.link_url ?? ""}
+              placeholder="https://conference.com/talks/your-session"
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="speaking-order">
+              Order index
+            </label>
+            <Input
+              id="speaking-order"
+              name="order_index"
+              type="number"
+              defaultValue={selected?.order_index ?? speaking.length}
+              min={0}
+            />
+          </div>
+        </form>
+        <div className="flex items-center justify-between gap-3 pt-4">
+          {selected ? (
+            <form
+              action={deleteProfileSpeaking}
+              onSubmit={(event) => {
+                if (!confirm("Delete this engagement?")) event.preventDefault();
+              }}
+            >
+              <input type="hidden" name="id" value={selected.id} />
+              <input type="hidden" name="event" value={selected.event} />
+              <Button variant="destructive" type="submit">
+                Delete
+              </Button>
+            </form>
+          ) : (
+            <span />
+          )}
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button type="submit" form="speaking-form">
+              {selected ? "Save" : "Create"}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </Card>
+  );
+}

--- a/app/admin/(dashboard)/site-profile/testimonials-manager.tsx
+++ b/app/admin/(dashboard)/site-profile/testimonials-manager.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { Modal } from "@/components/admin/modal";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import type { ProfileTestimonial } from "@/lib/supabase/types";
+
+import { deleteProfileTestimonial, upsertProfileTestimonial } from "./actions";
+
+type Props = {
+  testimonials: ProfileTestimonial[];
+  status?: string;
+  detail?: string;
+};
+
+export function TestimonialsManager({ testimonials, status, detail }: Props) {
+  const [open, setOpen] = useState(false);
+  const [selectedId, setSelectedId] = useState<string>("");
+
+  const selected = useMemo(
+    () => testimonials.find((item) => item.id === selectedId) ?? null,
+    [testimonials, selectedId],
+  );
+
+  const handleOpen = (id?: string) => {
+    setSelectedId(id ?? "");
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    setSelectedId("");
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <CardTitle>Testimonials</CardTitle>
+            <CardDescription>Quotes from clients or peers that deliver social proof.</CardDescription>
+          </div>
+          <Button size="sm" onClick={() => handleOpen()}>
+            Add testimonial
+          </Button>
+        </div>
+        {status === "testimonial-saved" ? (
+          <p className="text-sm text-emerald-600">Testimonial saved.</p>
+        ) : status === "testimonial-deleted" ? (
+          <p className="text-sm text-emerald-600">Removed testimonial {detail ? `“${detail}”` : ""}.</p>
+        ) : null}
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-hidden rounded-md border">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-muted/40">
+              <tr className="border-b">
+                <th className="px-3 py-2">Quote</th>
+                <th className="px-3 py-2">Attribution</th>
+                <th className="px-3 py-2">Role</th>
+                <th className="px-3 py-2">Link</th>
+                <th className="px-3 py-2">Order</th>
+                <th className="px-3 py-2">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {testimonials.length > 0 ? (
+                testimonials.map((item) => (
+                  <tr key={item.id} className="border-b last:border-0">
+                    <td className="px-3 py-2 text-muted-foreground">{item.quote}</td>
+                    <td className="px-3 py-2 font-medium">{item.attribution}</td>
+                    <td className="px-3 py-2">{item.role ?? "—"}</td>
+                    <td className="px-3 py-2 break-all">{item.link_url ?? "—"}</td>
+                    <td className="px-3 py-2">{item.order_index}</td>
+                    <td className="px-3 py-2">
+                      <Button size="sm" variant="outline" onClick={() => handleOpen(item.id)}>
+                        Edit
+                      </Button>
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={6} className="px-3 py-6 text-center text-muted-foreground">
+                    No testimonials yet. Add 2–3 concise quotes.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+
+      <Modal open={open} onClose={handleClose} title={selected ? "Edit testimonial" : "Add testimonial"}>
+        <form id="testimonial-form" key={selected?.id ?? "create"} action={upsertProfileTestimonial} className="grid gap-3">
+          <input type="hidden" name="id" value={selected?.id ?? ""} />
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="testimonial-quote">
+              Quote
+            </label>
+            <Textarea
+              id="testimonial-quote"
+              name="quote"
+              rows={3}
+              defaultValue={selected?.quote ?? ""}
+              required
+            />
+          </div>
+          <div className="grid gap-3 md:grid-cols-2">
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="testimonial-attribution">
+                Attribution
+              </label>
+              <Input
+                id="testimonial-attribution"
+                name="attribution"
+                defaultValue={selected?.attribution ?? ""}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium" htmlFor="testimonial-role">
+                Role / title
+              </label>
+              <Input id="testimonial-role" name="role" defaultValue={selected?.role ?? ""} placeholder="Security Lead" />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="testimonial-link">
+              Link URL
+            </label>
+            <Input
+              id="testimonial-link"
+              name="link_url"
+              defaultValue={selected?.link_url ?? ""}
+              placeholder="https://www.linkedin.com/..."
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium" htmlFor="testimonial-order">
+              Order index
+            </label>
+            <Input
+              id="testimonial-order"
+              name="order_index"
+              type="number"
+              defaultValue={selected?.order_index ?? testimonials.length}
+              min={0}
+            />
+          </div>
+        </form>
+        <div className="flex items-center justify-between gap-3 pt-4">
+          {selected ? (
+            <form
+              action={deleteProfileTestimonial}
+              onSubmit={(event) => {
+                if (!confirm("Delete this testimonial?")) event.preventDefault();
+              }}
+            >
+              <input type="hidden" name="id" value={selected.id} />
+              <input type="hidden" name="attribution" value={selected.attribution} />
+              <Button variant="destructive" type="submit">
+                Delete
+              </Button>
+            </form>
+          ) : (
+            <span />
+          )}
+          <div className="flex gap-2">
+            <Button type="button" variant="outline" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button type="submit" form="testimonial-form">
+              {selected ? "Save" : "Create"}
+            </Button>
+          </div>
+        </div>
+      </Modal>
+    </Card>
+  );
+}

--- a/app/admin/(dashboard)/site-profile/testimonials-manager.tsx
+++ b/app/admin/(dashboard)/site-profile/testimonials-manager.tsx
@@ -42,7 +42,9 @@ export function TestimonialsManager({ testimonials, status, detail }: Props) {
         <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div>
             <CardTitle>Testimonials</CardTitle>
-            <CardDescription>Quotes from clients or peers that deliver social proof.</CardDescription>
+            <CardDescription>
+              Quotes from clients or peers that deliver social proof.
+            </CardDescription>
           </div>
           <Button size="sm" onClick={() => handleOpen()}>
             Add testimonial
@@ -51,7 +53,9 @@ export function TestimonialsManager({ testimonials, status, detail }: Props) {
         {status === "testimonial-saved" ? (
           <p className="text-sm text-emerald-600">Testimonial saved.</p>
         ) : status === "testimonial-deleted" ? (
-          <p className="text-sm text-emerald-600">Removed testimonial {detail ? `“${detail}”` : ""}.</p>
+          <p className="text-sm text-emerald-600">
+            Removed testimonial {detail ? `“${detail}”` : ""}.
+          </p>
         ) : null}
       </CardHeader>
       <CardContent>
@@ -71,10 +75,10 @@ export function TestimonialsManager({ testimonials, status, detail }: Props) {
               {testimonials.length > 0 ? (
                 testimonials.map((item) => (
                   <tr key={item.id} className="border-b last:border-0">
-                    <td className="px-3 py-2 text-muted-foreground">{item.quote}</td>
+                    <td className="text-muted-foreground px-3 py-2">{item.quote}</td>
                     <td className="px-3 py-2 font-medium">{item.attribution}</td>
                     <td className="px-3 py-2">{item.role ?? "—"}</td>
-                    <td className="px-3 py-2 break-all">{item.link_url ?? "—"}</td>
+                    <td className="break-all px-3 py-2">{item.link_url ?? "—"}</td>
                     <td className="px-3 py-2">{item.order_index}</td>
                     <td className="px-3 py-2">
                       <Button size="sm" variant="outline" onClick={() => handleOpen(item.id)}>
@@ -85,7 +89,7 @@ export function TestimonialsManager({ testimonials, status, detail }: Props) {
                 ))
               ) : (
                 <tr>
-                  <td colSpan={6} className="px-3 py-6 text-center text-muted-foreground">
+                  <td colSpan={6} className="text-muted-foreground px-3 py-6 text-center">
                     No testimonials yet. Add 2–3 concise quotes.
                   </td>
                 </tr>
@@ -95,8 +99,17 @@ export function TestimonialsManager({ testimonials, status, detail }: Props) {
         </div>
       </CardContent>
 
-      <Modal open={open} onClose={handleClose} title={selected ? "Edit testimonial" : "Add testimonial"}>
-        <form id="testimonial-form" key={selected?.id ?? "create"} action={upsertProfileTestimonial} className="grid gap-3">
+      <Modal
+        open={open}
+        onClose={handleClose}
+        title={selected ? "Edit testimonial" : "Add testimonial"}
+      >
+        <form
+          id="testimonial-form"
+          key={selected?.id ?? "create"}
+          action={upsertProfileTestimonial}
+          className="grid gap-3"
+        >
           <input type="hidden" name="id" value={selected?.id ?? ""} />
           <div className="space-y-2">
             <label className="text-sm font-medium" htmlFor="testimonial-quote">
@@ -126,7 +139,12 @@ export function TestimonialsManager({ testimonials, status, detail }: Props) {
               <label className="text-sm font-medium" htmlFor="testimonial-role">
                 Role / title
               </label>
-              <Input id="testimonial-role" name="role" defaultValue={selected?.role ?? ""} placeholder="Security Lead" />
+              <Input
+                id="testimonial-role"
+                name="role"
+                defaultValue={selected?.role ?? ""}
+                placeholder="Security Lead"
+              />
             </div>
           </div>
           <div className="space-y-2">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -76,13 +76,11 @@ export default async function HomePage() {
             <div className="space-y-5">
               <div className="flex flex-wrap items-center gap-3 text-sm">
                 <span className="text-muted-foreground">{location}</span>
-                <div className="text-xs uppercase tracking-wide -mt-3">
-                  {hiringStatus}
-                </div>
+                <div className="-mt-3 text-xs uppercase tracking-wide">{hiringStatus}</div>
               </div>
               <div className="space-y-3">
                 <h1 className="text-3xl font-semibold tracking-tight sm:text-3xl">{heroHeading}</h1>
-                <p className="text-muted-foreground text-lg -mt-4">{heroSubheading}</p>
+                <p className="text-muted-foreground -mt-4 text-lg">{heroSubheading}</p>
               </div>
               <div className="flex flex-wrap gap-3">
                 <Button asChild>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -30,24 +30,27 @@ export default async function HomePage() {
   ]);
 
   const heroHeading =
-    settings?.hero_heading ??
     profile?.headline ??
+    settings?.hero_heading ??
     settings?.site_tagline ??
     "Security-led engineering for AI & cloud";
   const heroSubheading =
+    profile?.subheadline ??
     settings?.hero_subheading ??
-    profile?.summary ??
     "Partnering with product, platform, and security teams to accelerate delivery while improving trust—AI security, secure DevOps, and SOC automation.";
   const hiringStatus =
-    settings?.hiring_status ??
     profile?.hiring_status ??
+    settings?.hiring_status ??
     "Open to high‑impact security leadership roles";
-  const primaryCtaLabel = settings?.primary_cta_label ?? "View portfolio";
-  const primaryCtaUrl = settings?.primary_cta_url ?? "/portfolio";
-  const secondaryCtaLabel = settings?.secondary_cta_label ?? "Explore case studies";
-  const secondaryCtaUrl = settings?.secondary_cta_url ?? "/case-studies";
+  const primaryCtaLabel =
+    profile?.cta_primary_label ?? settings?.primary_cta_label ?? "View portfolio";
+  const primaryCtaUrl = profile?.cta_primary_url ?? settings?.primary_cta_url ?? "/portfolio";
+  const secondaryCtaLabel =
+    profile?.cta_secondary_label ?? settings?.secondary_cta_label ?? "Explore case studies";
+  const secondaryCtaUrl =
+    profile?.cta_secondary_url ?? settings?.secondary_cta_url ?? "/case-studies";
   const avatarUrl = profile?.avatar_url ?? "/profile-placeholder.svg";
-  const location = settings?.location ?? profile?.location ?? "Remote-first";
+  const location = profile?.location ?? settings?.location ?? "Remote-first";
 
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 py-12 sm:px-6 sm:py-16">
@@ -72,14 +75,14 @@ export default async function HomePage() {
             </div>
             <div className="space-y-5">
               <div className="flex flex-wrap items-center gap-3 text-sm">
-                <Badge variant="outline" className="text-xs uppercase tracking-wide">
-                  {hiringStatus}
-                </Badge>
                 <span className="text-muted-foreground">{location}</span>
+                <div className="text-xs uppercase tracking-wide -mt-3">
+                  {hiringStatus}
+                </div>
               </div>
               <div className="space-y-3">
-                <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">{heroHeading}</h1>
-                <p className="text-muted-foreground text-lg">{heroSubheading}</p>
+                <h1 className="text-3xl font-semibold tracking-tight sm:text-3xl">{heroHeading}</h1>
+                <p className="text-muted-foreground text-lg -mt-4">{heroSubheading}</p>
               </div>
               <div className="flex flex-wrap gap-3">
                 <Button asChild>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -77,9 +77,11 @@ export default async function ProfilePage() {
                 </p>
               ) : null}
               <p className="text-xl font-medium text-slate-200 sm:text-2xl">{profile.headline}</p>
-              {profile.subheadline ? <p className="text-slate-300 -mt-3">{profile.subheadline}</p> : null}
+              {profile.subheadline ? (
+                <p className="-mt-3 text-slate-300">{profile.subheadline}</p>
+              ) : null}
             </div>
-            <p className="text-foreground mt-3 text-med leading-relaxed sm:text-med">
+            <p className="text-foreground text-med sm:text-med mt-3 leading-relaxed">
               {profile.summary}
             </p>
           </div>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,7 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
 
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { IconCircle } from "@/components/ui/icon-circle";
@@ -49,8 +48,7 @@ export default async function ProfilePage() {
 
   const avatarUrl = profile?.avatar_url || "/profile-placeholder.svg";
   const resumePref = profile.resume_preference ?? "ai-security";
-  const resumeLabel =
-    resumes.find((r) => r.vertical === resumePref)?.label ?? "Download resume";
+  const resumeLabel = resumes.find((r) => r.vertical === resumePref)?.label ?? "Download resume";
   const primaryCta = buildCta(profile.cta_primary_label, profile.cta_primary_url);
   const secondaryCta = buildCta(profile.cta_secondary_label, profile.cta_secondary_url) ?? {
     label: "View resume",
@@ -63,55 +61,48 @@ export default async function ProfilePage() {
       <section className="relative overflow-hidden rounded-3xl border bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-8 text-slate-50 shadow-lg lg:p-12">
         <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
           <div className="max-w-2xl space-y-6">
-            <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-wide text-slate-200">
-              {profile.hiring_status ? (
-                <Badge variant="secondary" className="border-white/20 bg-white/10 text-white">
-                  {profile.hiring_status}
-                </Badge>
-              ) : null}
-              {profile.pronouns ? (
-                <Badge variant="outline" className="border-white/20 bg-white/5 text-white">
-                  {profile.pronouns}
-                </Badge>
-              ) : null}
-              {profile.phonetic_name ? (
-                <span className="rounded-full bg-white/10 px-3 py-1 text-[0.65rem] font-medium tracking-widest text-slate-200">
-                  Pronounced {profile.phonetic_name}
-                </span>
-              ) : null}
-            </div>
             <div className="space-y-2">
-              <p className="text-sm text-slate-300">{profile.location ?? "Remote-ready"}</p>
-              <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">{profile.full_name}</h1>
+              <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">
+                {profile.full_name}
+              </h1>
+              {profile.phonetic_name || profile.pronouns ? (
+                <p className="text-slate-300">
+                  {profile.phonetic_name ? (
+                    <>
+                      {profile.phonetic_name}
+                      {profile.pronouns ? " · " : ""}
+                    </>
+                  ) : null}
+                  {profile.pronouns ?? null}
+                </p>
+              ) : null}
               <p className="text-xl font-medium text-slate-200 sm:text-2xl">{profile.headline}</p>
-              {profile.subheadline ? <p className="text-slate-300">{profile.subheadline}</p> : null}
+              {profile.subheadline ? <p className="text-slate-300 -mt-3">{profile.subheadline}</p> : null}
             </div>
-            {profile.summary ? (
-              <p className="text-sm leading-relaxed text-slate-200 sm:text-base">{profile.summary}</p>
-            ) : null}
-            <div className="flex flex-wrap gap-3">
-              {primaryCta ? (
-                <Button asChild size="lg" className="bg-white text-slate-900 hover:bg-white/90">
-                  <Link href={primaryCta.url}>{primaryCta.label}</Link>
-                </Button>
-              ) : null}
-              {secondaryCta ? (
-                <Button asChild size="lg" variant="outline" className="border-white/40 text-white hover:bg-white/10">
-                  <Link href={secondaryCta.url}>{secondaryCta.label ?? resumeLabel}</Link>
-                </Button>
-              ) : null}
-            </div>
+            <p className="text-foreground mt-3 text-med leading-relaxed sm:text-med">
+              {profile.summary}
+            </p>
           </div>
           <div className="relative mx-auto h-44 w-44 overflow-hidden rounded-full border border-white/20 bg-white/10 sm:h-52 sm:w-52">
-            <Image src={avatarUrl} alt={profile.full_name} fill sizes="208px" className="object-cover" />
+            <Image
+              src={avatarUrl}
+              alt={profile.full_name}
+              fill
+              sizes="208px"
+              className="object-cover"
+            />
           </div>
         </div>
       </section>
 
       {profile.philosophy ? (
-        <section className="rounded-3xl border bg-muted/30 p-6 sm:p-8">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">My philosophy</h2>
-          <p className="mt-3 text-lg leading-relaxed text-foreground sm:text-xl">{profile.philosophy}</p>
+        <section className="bg-muted/30 rounded-3xl border p-6 sm:p-8">
+          <h2 className="text-muted-foreground text-sm font-semibold uppercase tracking-wide">
+            My philosophy
+          </h2>
+          <p className="text-foreground mt-3 text-lg leading-relaxed sm:text-xl">
+            {profile.philosophy}
+          </p>
         </section>
       ) : null}
 
@@ -119,21 +110,28 @@ export default async function ProfilePage() {
         <section className="space-y-6">
           <div>
             <h2 className="text-2xl font-semibold">Core expertise pillars</h2>
-            <p className="text-muted-foreground text-sm">Each pillar links to deeper proof—case studies, projects, or articles.</p>
+            <p className="text-muted-foreground text-sm">
+              Each pillar links to deeper proof—case studies, projects, or articles.
+            </p>
           </div>
           <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
             {pillars.map((pillar) => {
               const icon = pillar.icon_slug ? getSimpleIconBySlug(pillar.icon_slug) : null;
               const content = (
-                <Card className="h-full border-muted-foreground/20 shadow-sm transition hover:-translate-y-1 hover:shadow-lg">
+                <Card className="border-muted-foreground/20 h-full shadow-sm transition hover:-translate-y-1 hover:shadow-lg">
                   <CardContent className="flex h-full flex-col gap-3 p-6">
-                    <IconCircle icon={icon} className="border-muted-foreground/30 bg-muted/40 text-muted-foreground" />
+                    <IconCircle
+                      icon={icon}
+                      className="border-muted-foreground/30 bg-muted/40 text-muted-foreground"
+                    />
                     <div className="space-y-2">
-                      <h3 className="text-lg font-semibold text-foreground">{pillar.title}</h3>
-                      <p className="text-muted-foreground text-sm leading-relaxed">{pillar.description}</p>
+                      <h3 className="text-foreground text-lg font-semibold">{pillar.title}</h3>
+                      <p className="text-muted-foreground text-sm leading-relaxed">
+                        {pillar.description}
+                      </p>
                     </div>
                     {pillar.link_label && pillar.link_url ? (
-                      <span className="mt-auto inline-flex items-center gap-1 text-sm font-medium text-primary">
+                      <span className="text-primary mt-auto inline-flex items-center gap-1 text-sm font-medium">
                         {pillar.link_label} →
                       </span>
                     ) : null}
@@ -157,28 +155,38 @@ export default async function ProfilePage() {
         <section className="space-y-6">
           <div>
             <h2 className="text-2xl font-semibold">Career highlights</h2>
-            <p className="text-muted-foreground text-sm">A condensed timeline of engagements where measurable impact was delivered.</p>
+            <p className="text-muted-foreground text-sm">
+              A condensed timeline of engagements where measurable impact was delivered.
+            </p>
           </div>
           <div className="relative pl-6">
-            <span className="absolute left-2 top-1 h-full w-0.5 bg-gradient-to-b from-primary/60 via-primary/20 to-transparent" aria-hidden />
+            <span
+              className="from-primary/60 via-primary/20 absolute left-2 top-1 h-full w-0.5 bg-gradient-to-b to-transparent"
+              aria-hidden
+            />
             <ol className="space-y-6">
               {careerHighlights.map((highlight) => (
-                <li key={highlight.id} className="relative rounded-lg bg-muted/20 p-4 shadow-sm">
-                  <span className="absolute left-[-1.15rem] top-4 h-3 w-3 rounded-full border border-primary bg-background" aria-hidden />
+                <li key={highlight.id} className="bg-muted/20 relative rounded-lg p-4 shadow-sm">
+                  <span
+                    className="border-primary bg-background absolute left-[-1.15rem] top-4 h-3 w-3 rounded-full border"
+                    aria-hidden
+                  />
                   <div className="flex flex-wrap items-baseline justify-between gap-2">
-                    <h3 className="text-lg font-semibold text-foreground">{highlight.title}</h3>
+                    <h3 className="text-foreground text-lg font-semibold">{highlight.title}</h3>
                     {highlight.link_label && highlight.link_url ? (
-                      <Link href={highlight.link_url} className="text-sm font-medium text-primary">
+                      <Link href={highlight.link_url} className="text-primary text-sm font-medium">
                         {highlight.link_label} →
                       </Link>
                     ) : null}
                   </div>
-                  <p className="text-muted-foreground text-sm leading-relaxed">{highlight.description}</p>
+                  <p className="text-muted-foreground text-sm leading-relaxed">
+                    {highlight.description}
+                  </p>
                 </li>
               ))}
             </ol>
             {careerCta ? (
-              <div className="mt-6 text-sm font-medium text-primary">
+              <div className="text-primary mt-6 text-sm font-medium">
                 <Link href={careerCta.url}>{careerCta.label}</Link>
               </div>
             ) : null}
@@ -186,22 +194,24 @@ export default async function ProfilePage() {
         </section>
       ) : null}
 
-      {(speaking.length > 0 || recognitions.length > 0) ? (
+      {speaking.length > 0 || recognitions.length > 0 ? (
         <section className="grid gap-6 lg:grid-cols-2">
           {speaking.length > 0 ? (
-            <div className="rounded-3xl border bg-card p-6 shadow-sm">
+            <div className="bg-card rounded-3xl border p-6 shadow-sm">
               <h2 className="text-xl font-semibold">Speaking</h2>
               <p className="text-muted-foreground text-sm">Conferences, workshops, and talks.</p>
               <ul className="mt-4 space-y-3 text-sm">
                 {speaking.map((entry) => (
-                  <li key={entry.id} className="rounded-lg border border-muted-foreground/20 p-3">
+                  <li key={entry.id} className="border-muted-foreground/20 rounded-lg border p-3">
                     <div className="flex flex-wrap items-center justify-between gap-2">
-                      <span className="font-semibold text-foreground">{entry.event}</span>
-                      {entry.year ? <span className="text-muted-foreground text-xs">{entry.year}</span> : null}
+                      <span className="text-foreground font-semibold">{entry.event}</span>
+                      {entry.year ? (
+                        <span className="text-muted-foreground text-xs">{entry.year}</span>
+                      ) : null}
                     </div>
                     {entry.title ? <p className="text-muted-foreground">{entry.title}</p> : null}
                     {entry.link_url ? (
-                      <Link href={entry.link_url} className="text-xs font-medium text-primary">
+                      <Link href={entry.link_url} className="text-primary text-xs font-medium">
                         View details →
                       </Link>
                     ) : null}
@@ -211,19 +221,21 @@ export default async function ProfilePage() {
             </div>
           ) : null}
           {recognitions.length > 0 ? (
-            <div className="rounded-3xl border bg-card p-6 shadow-sm">
+            <div className="bg-card rounded-3xl border p-6 shadow-sm">
               <h2 className="text-xl font-semibold">Recognition</h2>
               <p className="text-muted-foreground text-sm">Certifications, awards, and features.</p>
               <ul className="mt-4 space-y-3 text-sm">
                 {recognitions.map((item) => (
-                  <li key={item.id} className="rounded-lg border border-muted-foreground/20 p-3">
+                  <li key={item.id} className="border-muted-foreground/20 rounded-lg border p-3">
                     <div className="flex flex-wrap items-center justify-between gap-2">
-                      <span className="font-semibold text-foreground">{item.title}</span>
-                      {item.year ? <span className="text-muted-foreground text-xs">{item.year}</span> : null}
+                      <span className="text-foreground font-semibold">{item.title}</span>
+                      {item.year ? (
+                        <span className="text-muted-foreground text-xs">{item.year}</span>
+                      ) : null}
                     </div>
                     {item.issuer ? <p className="text-muted-foreground">{item.issuer}</p> : null}
                     {item.link_url ? (
-                      <Link href={item.link_url} className="text-xs font-medium text-primary">
+                      <Link href={item.link_url} className="text-primary text-xs font-medium">
                         Verify credential →
                       </Link>
                     ) : null}
@@ -239,18 +251,28 @@ export default async function ProfilePage() {
         <section className="space-y-4">
           <div>
             <h2 className="text-2xl font-semibold">Testimonials</h2>
-            <p className="text-muted-foreground text-sm">What partners and leaders say about working together.</p>
+            <p className="text-muted-foreground text-sm">
+              What partners and leaders say about working together.
+            </p>
           </div>
           <div className="grid gap-4 md:grid-cols-2">
             {testimonials.map((testimonial) => (
-              <Card key={testimonial.id} className="border-muted-foreground/20 bg-background shadow-sm">
+              <Card
+                key={testimonial.id}
+                className="border-muted-foreground/20 bg-background shadow-sm"
+              >
                 <CardContent className="flex h-full flex-col gap-3 p-6">
-                  <p className="text-lg font-medium leading-relaxed text-foreground">{testimonial.quote}</p>
-                  <div className="mt-auto text-sm text-muted-foreground">
-                    <p className="font-semibold text-foreground">{testimonial.attribution}</p>
+                  <p className="text-foreground text-lg font-medium leading-relaxed">
+                    {testimonial.quote}
+                  </p>
+                  <div className="text-muted-foreground mt-auto text-sm">
+                    <p className="text-foreground font-semibold">{testimonial.attribution}</p>
                     {testimonial.role ? <p>{testimonial.role}</p> : null}
                     {testimonial.link_url ? (
-                      <Link href={testimonial.link_url} className="text-xs font-medium text-primary">
+                      <Link
+                        href={testimonial.link_url}
+                        className="text-primary text-xs font-medium"
+                      >
                         View source →
                       </Link>
                     ) : null}
@@ -265,8 +287,10 @@ export default async function ProfilePage() {
       {personalEntries.length > 0 ? (
         <section className="space-y-4">
           <div>
-            <h2 className="text-2xl font-semibold">Beyond security</h2>
-            <p className="text-muted-foreground text-sm">Human details that shape how collaboration feels.</p>
+            <h2 className="text-2xl font-semibold">Beyond work life</h2>
+            <p className="text-muted-foreground text-sm">
+              Human details that shape how collaboration feels.
+            </p>
           </div>
           <div className="grid gap-4 md:grid-cols-2">
             {personalEntries.map((entry) => {
@@ -276,8 +300,10 @@ export default async function ProfilePage() {
                   <CardContent className="flex items-start gap-4 p-5">
                     <IconCircle icon={icon} className="border-muted-foreground/30 bg-background" />
                     <div className="space-y-1">
-                      <h3 className="text-lg font-semibold text-foreground">{entry.title}</h3>
-                      <p className="text-muted-foreground text-sm leading-relaxed">{entry.description}</p>
+                      <h3 className="text-foreground text-lg font-semibold">{entry.title}</h3>
+                      <p className="text-muted-foreground text-sm leading-relaxed">
+                        {entry.description}
+                      </p>
                     </div>
                   </CardContent>
                 </Card>
@@ -288,10 +314,11 @@ export default async function ProfilePage() {
       ) : null}
 
       {(primaryCta || secondaryCta) && (
-        <section className="rounded-3xl border border-primary/30 bg-primary/5 p-8 text-center">
-          <h2 className="text-2xl font-semibold text-foreground">Ready to go deeper?</h2>
+        <section className="border-primary/30 bg-primary/5 rounded-3xl border p-8 text-center">
+          <h2 className="text-foreground text-2xl font-semibold">Ready to go deeper?</h2>
           <p className="text-muted-foreground mt-2 text-sm">
-            Explore detailed proof points and tailor engagements that accelerate your security roadmap.
+            Explore detailed proof points and tailor engagements that accelerate your security
+            roadmap.
           </p>
           <div className="mt-6 flex flex-wrap justify-center gap-4">
             {primaryCta ? (

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,199 +1,312 @@
 import Image from "next/image";
+import Link from "next/link";
 
 import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { getSiteProfile, getResumes } from "@/lib/supabase/queries";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { IconCircle } from "@/components/ui/icon-circle";
+import {
+  getProfileCareerHighlights,
+  getProfilePersonalEntries,
+  getProfilePillars,
+  getProfileRecognitions,
+  getProfileSpeaking,
+  getProfileTestimonials,
+  getResumes,
+  getSiteProfile,
+} from "@/lib/supabase/queries";
+import { getSimpleIconBySlug } from "@/lib/simple-icons";
+
+function buildCta(label?: string | null, url?: string | null) {
+  if (!label || !url) return null;
+  return { label, url };
+}
 
 export default async function ProfilePage() {
-  const [profile, resumes] = await Promise.all([getSiteProfile(), getResumes()]);
-  const avatarUrl = profile?.avatar_url ?? "/profile-placeholder.svg";
-  const resumePref = profile?.resume_preference ?? "ai-security";
-  const resumeLabel = resumes.find((r) => r.vertical === resumePref)?.label ?? "Resume";
+  const [
+    profile,
+    resumes,
+    pillars,
+    careerHighlights,
+    speaking,
+    recognitions,
+    testimonials,
+    personalEntries,
+  ] = await Promise.all([
+    getSiteProfile(),
+    getResumes(),
+    getProfilePillars(),
+    getProfileCareerHighlights(),
+    getProfileSpeaking(),
+    getProfileRecognitions(),
+    getProfileTestimonials(),
+    getProfilePersonalEntries(),
+  ]);
+
+  if (!profile) {
+    return null;
+  }
+
+  const avatarUrl = profile?.avatar_url || "/profile-placeholder.svg";
+  const resumePref = profile.resume_preference ?? "ai-security";
+  const resumeLabel =
+    resumes.find((r) => r.vertical === resumePref)?.label ?? "Download resume";
+  const primaryCta = buildCta(profile.cta_primary_label, profile.cta_primary_url);
+  const secondaryCta = buildCta(profile.cta_secondary_label, profile.cta_secondary_url) ?? {
+    label: "View resume",
+    url: `/resume/${resumePref}`,
+  };
+  const careerCta = buildCta(profile.career_cta_label, profile.career_cta_url);
 
   return (
-    <div className="mx-auto flex w-full max-w-4xl flex-col gap-10 px-4 py-12 sm:px-6 sm:py-16">
-      <header className="flex flex-col gap-6 sm:flex-row sm:items-center">
-        <div className="relative h-28 w-28 overflow-hidden rounded-full border">
-          <Image
-            src={avatarUrl}
-            alt={profile?.full_name ?? "Profile"}
-            fill
-            sizes="112px"
-            className="object-cover"
-          />
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-16 px-4 py-12 sm:px-6 lg:px-8">
+      <section className="relative overflow-hidden rounded-3xl border bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-8 text-slate-50 shadow-lg lg:p-12">
+        <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+          <div className="max-w-2xl space-y-6">
+            <div className="flex flex-wrap items-center gap-2 text-xs uppercase tracking-wide text-slate-200">
+              {profile.hiring_status ? (
+                <Badge variant="secondary" className="border-white/20 bg-white/10 text-white">
+                  {profile.hiring_status}
+                </Badge>
+              ) : null}
+              {profile.pronouns ? (
+                <Badge variant="outline" className="border-white/20 bg-white/5 text-white">
+                  {profile.pronouns}
+                </Badge>
+              ) : null}
+              {profile.phonetic_name ? (
+                <span className="rounded-full bg-white/10 px-3 py-1 text-[0.65rem] font-medium tracking-widest text-slate-200">
+                  Pronounced {profile.phonetic_name}
+                </span>
+              ) : null}
+            </div>
+            <div className="space-y-2">
+              <p className="text-sm text-slate-300">{profile.location ?? "Remote-ready"}</p>
+              <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">{profile.full_name}</h1>
+              <p className="text-xl font-medium text-slate-200 sm:text-2xl">{profile.headline}</p>
+              {profile.subheadline ? <p className="text-slate-300">{profile.subheadline}</p> : null}
+            </div>
+            {profile.summary ? (
+              <p className="text-sm leading-relaxed text-slate-200 sm:text-base">{profile.summary}</p>
+            ) : null}
+            <div className="flex flex-wrap gap-3">
+              {primaryCta ? (
+                <Button asChild size="lg" className="bg-white text-slate-900 hover:bg-white/90">
+                  <Link href={primaryCta.url}>{primaryCta.label}</Link>
+                </Button>
+              ) : null}
+              {secondaryCta ? (
+                <Button asChild size="lg" variant="outline" className="border-white/40 text-white hover:bg-white/10">
+                  <Link href={secondaryCta.url}>{secondaryCta.label ?? resumeLabel}</Link>
+                </Button>
+              ) : null}
+            </div>
+          </div>
+          <div className="relative mx-auto h-44 w-44 overflow-hidden rounded-full border border-white/20 bg-white/10 sm:h-52 sm:w-52">
+            <Image src={avatarUrl} alt={profile.full_name} fill sizes="208px" className="object-cover" />
+          </div>
         </div>
-        <div className="space-y-2">
-          <div className="flex flex-wrap items-center gap-3 text-sm">
-            {profile?.hiring_status ? (
-              <Badge variant="outline" className="uppercase tracking-wide">
-                {profile.hiring_status}
-              </Badge>
-            ) : null}
-            {profile?.pronouns ? (
-              <Badge variant="secondary" className="uppercase tracking-wide">
-                {profile.pronouns}
-              </Badge>
-            ) : null}
-            {profile?.location ? (
-              <span className="text-muted-foreground">{profile.location}</span>
+      </section>
+
+      {profile.philosophy ? (
+        <section className="rounded-3xl border bg-muted/30 p-6 sm:p-8">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">My philosophy</h2>
+          <p className="mt-3 text-lg leading-relaxed text-foreground sm:text-xl">{profile.philosophy}</p>
+        </section>
+      ) : null}
+
+      {pillars.length > 0 ? (
+        <section className="space-y-6">
+          <div>
+            <h2 className="text-2xl font-semibold">Core expertise pillars</h2>
+            <p className="text-muted-foreground text-sm">Each pillar links to deeper proof—case studies, projects, or articles.</p>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            {pillars.map((pillar) => {
+              const icon = pillar.icon_slug ? getSimpleIconBySlug(pillar.icon_slug) : null;
+              const content = (
+                <Card className="h-full border-muted-foreground/20 shadow-sm transition hover:-translate-y-1 hover:shadow-lg">
+                  <CardContent className="flex h-full flex-col gap-3 p-6">
+                    <IconCircle icon={icon} className="border-muted-foreground/30 bg-muted/40 text-muted-foreground" />
+                    <div className="space-y-2">
+                      <h3 className="text-lg font-semibold text-foreground">{pillar.title}</h3>
+                      <p className="text-muted-foreground text-sm leading-relaxed">{pillar.description}</p>
+                    </div>
+                    {pillar.link_label && pillar.link_url ? (
+                      <span className="mt-auto inline-flex items-center gap-1 text-sm font-medium text-primary">
+                        {pillar.link_label} →
+                      </span>
+                    ) : null}
+                  </CardContent>
+                </Card>
+              );
+
+              return pillar.link_label && pillar.link_url ? (
+                <Link key={pillar.id} href={pillar.link_url} className="block h-full">
+                  {content}
+                </Link>
+              ) : (
+                <div key={pillar.id}>{content}</div>
+              );
+            })}
+          </div>
+        </section>
+      ) : null}
+
+      {careerHighlights.length > 0 ? (
+        <section className="space-y-6">
+          <div>
+            <h2 className="text-2xl font-semibold">Career highlights</h2>
+            <p className="text-muted-foreground text-sm">A condensed timeline of engagements where measurable impact was delivered.</p>
+          </div>
+          <div className="relative pl-6">
+            <span className="absolute left-2 top-1 h-full w-0.5 bg-gradient-to-b from-primary/60 via-primary/20 to-transparent" aria-hidden />
+            <ol className="space-y-6">
+              {careerHighlights.map((highlight) => (
+                <li key={highlight.id} className="relative rounded-lg bg-muted/20 p-4 shadow-sm">
+                  <span className="absolute left-[-1.15rem] top-4 h-3 w-3 rounded-full border border-primary bg-background" aria-hidden />
+                  <div className="flex flex-wrap items-baseline justify-between gap-2">
+                    <h3 className="text-lg font-semibold text-foreground">{highlight.title}</h3>
+                    {highlight.link_label && highlight.link_url ? (
+                      <Link href={highlight.link_url} className="text-sm font-medium text-primary">
+                        {highlight.link_label} →
+                      </Link>
+                    ) : null}
+                  </div>
+                  <p className="text-muted-foreground text-sm leading-relaxed">{highlight.description}</p>
+                </li>
+              ))}
+            </ol>
+            {careerCta ? (
+              <div className="mt-6 text-sm font-medium text-primary">
+                <Link href={careerCta.url}>{careerCta.label}</Link>
+              </div>
             ) : null}
           </div>
-          <h1 className="text-4xl font-semibold tracking-tight">
-            {profile?.full_name ?? "Profile"}
-          </h1>
-          {profile?.phonetic_name ? (
-            <p className="text-muted-foreground text-sm">Pronounced: {profile.phonetic_name}</p>
-          ) : null}
-          {profile?.headline ? (
-            <p className="text-muted-foreground text-lg">{profile.headline}</p>
-          ) : null}
-        </div>
-      </header>
+        </section>
+      ) : null}
 
-      <section className="grid gap-6 md:grid-cols-3">
-        <Card className="md:col-span-2">
-          <CardHeader>
-            <CardTitle>About</CardTitle>
-            <CardDescription>Overview for recruiters and interviewers.</CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-3 text-sm">
-            {profile?.summary ? (
-              <p className="text-foreground text-base leading-relaxed">{profile.summary}</p>
-            ) : (
-              <p className="text-muted-foreground">Add a summary in Site Profile.</p>
-            )}
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>Resume</CardTitle>
-            <CardDescription>Default vertical preference</CardDescription>
-          </CardHeader>
-          <CardContent className="text-sm">
-            <a href={`/resume/${resumePref}`} className="text-primary hover:underline">
-              {resumeLabel} →
-            </a>
-          </CardContent>
-        </Card>
-      </section>
-
-      <section className="grid gap-6 md:grid-cols-2">
-        <Card>
-          <CardHeader>
-            <CardTitle>Hobbies</CardTitle>
-            <CardDescription>Outside of work</CardDescription>
-          </CardHeader>
-          <CardContent className="text-muted-foreground text-sm">
-            {profile?.hobbies && profile.hobbies.length > 0 ? (
-              <ul className="list-disc space-y-1 pl-5">
-                {profile.hobbies.map((h) => (
-                  <li key={h}>{h}</li>
+      {(speaking.length > 0 || recognitions.length > 0) ? (
+        <section className="grid gap-6 lg:grid-cols-2">
+          {speaking.length > 0 ? (
+            <div className="rounded-3xl border bg-card p-6 shadow-sm">
+              <h2 className="text-xl font-semibold">Speaking</h2>
+              <p className="text-muted-foreground text-sm">Conferences, workshops, and talks.</p>
+              <ul className="mt-4 space-y-3 text-sm">
+                {speaking.map((entry) => (
+                  <li key={entry.id} className="rounded-lg border border-muted-foreground/20 p-3">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <span className="font-semibold text-foreground">{entry.event}</span>
+                      {entry.year ? <span className="text-muted-foreground text-xs">{entry.year}</span> : null}
+                    </div>
+                    {entry.title ? <p className="text-muted-foreground">{entry.title}</p> : null}
+                    {entry.link_url ? (
+                      <Link href={entry.link_url} className="text-xs font-medium text-primary">
+                        View details →
+                      </Link>
+                    ) : null}
+                  </li>
                 ))}
               </ul>
-            ) : (
-              <p>Add hobbies in Site Profile.</p>
-            )}
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardTitle>Special Interests</CardTitle>
-            <CardDescription>What I’m exploring</CardDescription>
-          </CardHeader>
-          <CardContent className="text-muted-foreground text-sm">
-            {profile?.interests && profile.interests.length > 0 ? (
-              <ul className="list-disc space-y-1 pl-5">
-                {profile.interests.map((i) => (
-                  <li key={i}>{i}</li>
+            </div>
+          ) : null}
+          {recognitions.length > 0 ? (
+            <div className="rounded-3xl border bg-card p-6 shadow-sm">
+              <h2 className="text-xl font-semibold">Recognition</h2>
+              <p className="text-muted-foreground text-sm">Certifications, awards, and features.</p>
+              <ul className="mt-4 space-y-3 text-sm">
+                {recognitions.map((item) => (
+                  <li key={item.id} className="rounded-lg border border-muted-foreground/20 p-3">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <span className="font-semibold text-foreground">{item.title}</span>
+                      {item.year ? <span className="text-muted-foreground text-xs">{item.year}</span> : null}
+                    </div>
+                    {item.issuer ? <p className="text-muted-foreground">{item.issuer}</p> : null}
+                    {item.link_url ? (
+                      <Link href={item.link_url} className="text-xs font-medium text-primary">
+                        Verify credential →
+                      </Link>
+                    ) : null}
+                  </li>
                 ))}
               </ul>
-            ) : (
-              <p>Add interests in Site Profile.</p>
-            )}
-          </CardContent>
-        </Card>
-      </section>
-
-      {(profile?.languages && profile.languages.length > 0) || profile?.access_notes ? (
-        <section className="grid gap-6 md:grid-cols-2">
-          {profile?.languages && profile.languages.length > 0 ? (
-            <Card>
-              <CardHeader>
-                <CardTitle>Languages</CardTitle>
-                <CardDescription>How I collaborate</CardDescription>
-              </CardHeader>
-              <CardContent className="text-muted-foreground text-sm">
-                <ul className="list-disc space-y-1 pl-5">
-                  {profile.languages?.map((language) => (
-                    <li key={language}>{language}</li>
-                  ))}
-                </ul>
-              </CardContent>
-            </Card>
-          ) : null}
-          {profile?.access_notes ? (
-            <Card>
-              <CardHeader>
-                <CardTitle>Access & preferences</CardTitle>
-                <CardDescription>Supportive collaboration</CardDescription>
-              </CardHeader>
-              <CardContent className="text-muted-foreground text-sm">
-                <p>{profile.access_notes}</p>
-              </CardContent>
-            </Card>
+            </div>
           ) : null}
         </section>
       ) : null}
 
-      {(profile?.speaking && profile.speaking.length > 0) ||
-      (profile?.certifications && profile.certifications.length > 0) ||
-      (profile?.awards && profile.awards.length > 0) ? (
-        <section className="grid gap-6 md:grid-cols-3">
-          {profile?.speaking && profile.speaking.length > 0 ? (
-            <Card>
-              <CardHeader>
-                <CardTitle>Speaking</CardTitle>
-              </CardHeader>
-              <CardContent className="text-muted-foreground text-sm">
-                <ul className="list-disc space-y-1 pl-5">
-                  {profile.speaking.map((s) => (
-                    <li key={s}>{s}</li>
-                  ))}
-                </ul>
-              </CardContent>
-            </Card>
-          ) : null}
-          {profile?.certifications && profile.certifications.length > 0 ? (
-            <Card>
-              <CardHeader>
-                <CardTitle>Certifications</CardTitle>
-              </CardHeader>
-              <CardContent className="text-muted-foreground text-sm">
-                <ul className="list-disc space-y-1 pl-5">
-                  {profile.certifications.map((c) => (
-                    <li key={c}>{c}</li>
-                  ))}
-                </ul>
-              </CardContent>
-            </Card>
-          ) : null}
-          {profile?.awards && profile.awards.length > 0 ? (
-            <Card>
-              <CardHeader>
-                <CardTitle>Awards</CardTitle>
-              </CardHeader>
-              <CardContent className="text-muted-foreground text-sm">
-                <ul className="list-disc space-y-1 pl-5">
-                  {profile.awards.map((a) => (
-                    <li key={a}>{a}</li>
-                  ))}
-                </ul>
-              </CardContent>
-            </Card>
-          ) : null}
+      {testimonials.length > 0 ? (
+        <section className="space-y-4">
+          <div>
+            <h2 className="text-2xl font-semibold">Testimonials</h2>
+            <p className="text-muted-foreground text-sm">What partners and leaders say about working together.</p>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            {testimonials.map((testimonial) => (
+              <Card key={testimonial.id} className="border-muted-foreground/20 bg-background shadow-sm">
+                <CardContent className="flex h-full flex-col gap-3 p-6">
+                  <p className="text-lg font-medium leading-relaxed text-foreground">{testimonial.quote}</p>
+                  <div className="mt-auto text-sm text-muted-foreground">
+                    <p className="font-semibold text-foreground">{testimonial.attribution}</p>
+                    {testimonial.role ? <p>{testimonial.role}</p> : null}
+                    {testimonial.link_url ? (
+                      <Link href={testimonial.link_url} className="text-xs font-medium text-primary">
+                        View source →
+                      </Link>
+                    ) : null}
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
         </section>
       ) : null}
+
+      {personalEntries.length > 0 ? (
+        <section className="space-y-4">
+          <div>
+            <h2 className="text-2xl font-semibold">Beyond security</h2>
+            <p className="text-muted-foreground text-sm">Human details that shape how collaboration feels.</p>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            {personalEntries.map((entry) => {
+              const icon = entry.icon_slug ? getSimpleIconBySlug(entry.icon_slug) : null;
+              return (
+                <Card key={entry.id} className="border-muted-foreground/20 bg-muted/20">
+                  <CardContent className="flex items-start gap-4 p-5">
+                    <IconCircle icon={icon} className="border-muted-foreground/30 bg-background" />
+                    <div className="space-y-1">
+                      <h3 className="text-lg font-semibold text-foreground">{entry.title}</h3>
+                      <p className="text-muted-foreground text-sm leading-relaxed">{entry.description}</p>
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        </section>
+      ) : null}
+
+      {(primaryCta || secondaryCta) && (
+        <section className="rounded-3xl border border-primary/30 bg-primary/5 p-8 text-center">
+          <h2 className="text-2xl font-semibold text-foreground">Ready to go deeper?</h2>
+          <p className="text-muted-foreground mt-2 text-sm">
+            Explore detailed proof points and tailor engagements that accelerate your security roadmap.
+          </p>
+          <div className="mt-6 flex flex-wrap justify-center gap-4">
+            {primaryCta ? (
+              <Button asChild size="lg">
+                <Link href={primaryCta.url}>{primaryCta.label}</Link>
+              </Button>
+            ) : null}
+            {secondaryCta ? (
+              <Button asChild size="lg" variant="outline">
+                <Link href={secondaryCta.url}>{secondaryCta.label ?? resumeLabel}</Link>
+              </Button>
+            ) : null}
+          </div>
+        </section>
+      )}
     </div>
   );
 }

--- a/lib/admin/queries.ts
+++ b/lib/admin/queries.ts
@@ -2,6 +2,12 @@ import type {
   Article,
   CaseStudy,
   ContactRequest,
+  ProfileCareerHighlight,
+  ProfilePersonalEntry,
+  ProfilePillar,
+  ProfileRecognition,
+  ProfileSpeakingEngagement,
+  ProfileTestimonial,
   Project,
   Resume,
   SiteProfile,
@@ -177,6 +183,72 @@ export async function fetchSiteProfile(): Promise<SiteProfile | null> {
     .maybeSingle();
   if (error) throw new Error(error.message);
   return (data as SiteProfile | null) ?? null;
+}
+
+export async function fetchProfilePillars(): Promise<ProfilePillar[]> {
+  const admin = createSupabaseAdminClient();
+  const { data, error } = await admin
+    .from("profile_pillars")
+    .select("*")
+    .order("order_index", { ascending: true })
+    .order("created_at", { ascending: true });
+  if (error) throw new Error(error.message);
+  return (data as ProfilePillar[]) ?? [];
+}
+
+export async function fetchProfileCareerHighlights(): Promise<ProfileCareerHighlight[]> {
+  const admin = createSupabaseAdminClient();
+  const { data, error } = await admin
+    .from("profile_career_highlights")
+    .select("*")
+    .order("order_index", { ascending: true })
+    .order("created_at", { ascending: true });
+  if (error) throw new Error(error.message);
+  return (data as ProfileCareerHighlight[]) ?? [];
+}
+
+export async function fetchProfileSpeaking(): Promise<ProfileSpeakingEngagement[]> {
+  const admin = createSupabaseAdminClient();
+  const { data, error } = await admin
+    .from("profile_speaking_engagements")
+    .select("*")
+    .order("order_index", { ascending: true })
+    .order("created_at", { ascending: true });
+  if (error) throw new Error(error.message);
+  return (data as ProfileSpeakingEngagement[]) ?? [];
+}
+
+export async function fetchProfileRecognitions(): Promise<ProfileRecognition[]> {
+  const admin = createSupabaseAdminClient();
+  const { data, error } = await admin
+    .from("profile_recognitions")
+    .select("*")
+    .order("order_index", { ascending: true })
+    .order("created_at", { ascending: true });
+  if (error) throw new Error(error.message);
+  return (data as ProfileRecognition[]) ?? [];
+}
+
+export async function fetchProfileTestimonials(): Promise<ProfileTestimonial[]> {
+  const admin = createSupabaseAdminClient();
+  const { data, error } = await admin
+    .from("profile_testimonials")
+    .select("*")
+    .order("order_index", { ascending: true })
+    .order("created_at", { ascending: true });
+  if (error) throw new Error(error.message);
+  return (data as ProfileTestimonial[]) ?? [];
+}
+
+export async function fetchProfilePersonalEntries(): Promise<ProfilePersonalEntry[]> {
+  const admin = createSupabaseAdminClient();
+  const { data, error } = await admin
+    .from("profile_personal_entries")
+    .select("*")
+    .order("order_index", { ascending: true })
+    .order("created_at", { ascending: true });
+  if (error) throw new Error(error.message);
+  return (data as ProfilePersonalEntry[]) ?? [];
 }
 
 export async function fetchEventSummary(): Promise<Array<{ type: string; count: number }>> {

--- a/lib/simple-icons.ts
+++ b/lib/simple-icons.ts
@@ -1,5 +1,20 @@
 import type { SimpleIcon } from "simple-icons";
-import { siGithub, siInstagram, siRss, siSlack, siThreads, siX, siYoutube, siHomeassistant, siStrava, siGoogletranslate, siOpenai, siGithubactions, siSplunk, siOkta } from "simple-icons";
+import {
+  siGithub,
+  siInstagram,
+  siRss,
+  siSlack,
+  siThreads,
+  siX,
+  siYoutube,
+  siHomeassistant,
+  siStrava,
+  siGoogletranslate,
+  siOpenai,
+  siGithubactions,
+  siSplunk,
+  siOkta,
+} from "simple-icons";
 
 const siLinkedin: SimpleIcon = {
   title: "LinkedIn",

--- a/lib/simple-icons.ts
+++ b/lib/simple-icons.ts
@@ -1,5 +1,5 @@
 import type { SimpleIcon } from "simple-icons";
-import { siGithub, siInstagram, siRss, siSlack, siThreads, siX, siYoutube } from "simple-icons";
+import { siGithub, siInstagram, siRss, siSlack, siThreads, siX, siYoutube, siHomeassistant, siStrava, siGoogletranslate, siOpenai, siGithubactions, siSplunk, siOkta } from "simple-icons";
 
 const siLinkedin: SimpleIcon = {
   title: "LinkedIn",
@@ -20,6 +20,13 @@ const iconMap: Record<string, SimpleIcon> = {
   twitter: siX,
   x: siX,
   youtube: siYoutube,
+  homeassistant: siHomeassistant,
+  strava: siStrava,
+  googletranslate: siGoogletranslate,
+  openai: siOpenai,
+  githubactions: siGithubactions,
+  splunk: siSplunk,
+  okta: siOkta,
 };
 
 export function getSimpleIconBySlug(slug: string | null | undefined): SimpleIcon | null {
@@ -48,6 +55,13 @@ const slugAliases: Record<string, string> = {
   blog: "rss",
   newsletter: "rss",
   substack: "rss",
+  homeassistant: "homeassistant",
+  strava: "strava",
+  googletranslate: "googletranslate",
+  openai: "openai",
+  githubactions: "githubactions",
+  splunk: "splunk",
+  okta: "okta",
 };
 
 const textMatchers: Array<{ pattern: RegExp; slug: string }> = [
@@ -59,6 +73,13 @@ const textMatchers: Array<{ pattern: RegExp; slug: string }> = [
   { pattern: /instagram|\big\b/i, slug: "instagram" },
   { pattern: /threads/i, slug: "threads" },
   { pattern: /rss|blog|newsletter|substack/i, slug: "rss" },
+  { pattern: /home[\s-]?assistant/i, slug: "homeassistant" },
+  { pattern: /strava/i, slug: "strava" },
+  { pattern: /google[\s-]?translate/i, slug: "googletranslate" },
+  { pattern: /openai/i, slug: "openai" },
+  { pattern: /github[\s-]?actions/i, slug: "githubactions" },
+  { pattern: /splunk/i, slug: "splunk" },
+  { pattern: /okta/i, slug: "okta" },
 ];
 
 const hostMatchers: Array<{ pattern: RegExp; slug: string }> = [
@@ -76,6 +97,13 @@ const hostMatchers: Array<{ pattern: RegExp; slug: string }> = [
   { pattern: /dev\.to$/i, slug: "rss" },
   { pattern: /hashnode\.com$/i, slug: "rss" },
   { pattern: /rss\./i, slug: "rss" },
+  { pattern: /homeassistant\.io$/i, slug: "homeassistant" },
+  { pattern: /strava\.com$/i, slug: "strava" },
+  { pattern: /translate\.google\.com$/i, slug: "googletranslate" },
+  { pattern: /openai\.com$/i, slug: "openai" },
+  { pattern: /github\.com\/features\/actions$/i, slug: "githubactions" },
+  { pattern: /splunk\.com$/i, slug: "splunk" },
+  { pattern: /okta\.com$/i, slug: "okta" },
 ];
 
 function applyAlias(slug: string | null | undefined): string | null {

--- a/lib/supabase/queries.ts
+++ b/lib/supabase/queries.ts
@@ -6,13 +6,19 @@ import type {
   Article,
   CaseStudy,
   ContactLink,
+  MdxDocument,
+  ProfileCareerHighlight,
+  ProfilePersonalEntry,
+  ProfilePillar,
+  ProfileRecognition,
+  ProfileSpeakingEngagement,
+  ProfileTestimonial,
   Project,
   Resume,
   SiteProfile,
   SiteSettings,
   SocialPost,
   Vertical,
-  MdxDocument,
 } from "./types";
 import { readStorageText } from "./storage";
 
@@ -361,6 +367,66 @@ export const getSiteProfile = cache(async (): Promise<SiteProfile | null> => {
   }
 
   return data as SiteProfile | null;
+});
+
+export const getProfilePillars = cache(async (): Promise<ProfilePillar[]> => {
+  const supabase = await getClient();
+  const { data, error } = await supabase
+    .from("profile_pillars")
+    .select("*")
+    .order("order_index", { ascending: true })
+    .order("created_at", { ascending: true });
+  return unwrap<ProfilePillar[]>(data, error, "Unable to load profile pillars");
+});
+
+export const getProfileCareerHighlights = cache(async (): Promise<ProfileCareerHighlight[]> => {
+  const supabase = await getClient();
+  const { data, error } = await supabase
+    .from("profile_career_highlights")
+    .select("*")
+    .order("order_index", { ascending: true })
+    .order("created_at", { ascending: true });
+  return unwrap<ProfileCareerHighlight[]>(data, error, "Unable to load career highlights");
+});
+
+export const getProfileSpeaking = cache(async (): Promise<ProfileSpeakingEngagement[]> => {
+  const supabase = await getClient();
+  const { data, error } = await supabase
+    .from("profile_speaking_engagements")
+    .select("*")
+    .order("order_index", { ascending: true })
+    .order("created_at", { ascending: true });
+  return unwrap<ProfileSpeakingEngagement[]>(data, error, "Unable to load speaking engagements");
+});
+
+export const getProfileRecognitions = cache(async (): Promise<ProfileRecognition[]> => {
+  const supabase = await getClient();
+  const { data, error } = await supabase
+    .from("profile_recognitions")
+    .select("*")
+    .order("order_index", { ascending: true })
+    .order("created_at", { ascending: true });
+  return unwrap<ProfileRecognition[]>(data, error, "Unable to load recognitions");
+});
+
+export const getProfileTestimonials = cache(async (): Promise<ProfileTestimonial[]> => {
+  const supabase = await getClient();
+  const { data, error } = await supabase
+    .from("profile_testimonials")
+    .select("*")
+    .order("order_index", { ascending: true })
+    .order("created_at", { ascending: true });
+  return unwrap<ProfileTestimonial[]>(data, error, "Unable to load testimonials");
+});
+
+export const getProfilePersonalEntries = cache(async (): Promise<ProfilePersonalEntry[]> => {
+  const supabase = await getClient();
+  const { data, error } = await supabase
+    .from("profile_personal_entries")
+    .select("*")
+    .order("order_index", { ascending: true })
+    .order("created_at", { ascending: true });
+  return unwrap<ProfilePersonalEntry[]>(data, error, "Unable to load personal entries");
 });
 
 export const getContactLinks = cache(async (): Promise<ContactLink[]> => {

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -108,12 +108,79 @@ export type Highlight = {
   value: string;
 };
 
+export type ProfilePillar = {
+  id: string;
+  title: string;
+  description: string;
+  icon_slug: string | null;
+  link_label: string | null;
+  link_url: string | null;
+  order_index: number;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ProfileCareerHighlight = {
+  id: string;
+  title: string;
+  description: string;
+  link_label: string | null;
+  link_url: string | null;
+  order_index: number;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ProfileSpeakingEngagement = {
+  id: string;
+  event: string;
+  title: string | null;
+  year: string | null;
+  link_url: string | null;
+  order_index: number;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ProfileRecognition = {
+  id: string;
+  title: string;
+  issuer: string | null;
+  year: string | null;
+  link_url: string | null;
+  order_index: number;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ProfileTestimonial = {
+  id: string;
+  quote: string;
+  attribution: string;
+  role: string | null;
+  link_url: string | null;
+  order_index: number;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ProfilePersonalEntry = {
+  id: string;
+  title: string;
+  description: string;
+  icon_slug: string | null;
+  order_index: number;
+  created_at: string;
+  updated_at: string;
+};
+
 export type SiteProfile = {
   id: string;
   full_name: string;
   headline: string;
   subheadline: string | null;
   summary: string | null;
+  philosophy: string | null;
   avatar_url: string | null;
   location: string | null;
   hiring_status: string | null;
@@ -128,6 +195,12 @@ export type SiteProfile = {
   phonetic_name?: string | null;
   languages?: string[] | null;
   access_notes?: string | null;
+  cta_primary_label?: string | null;
+  cta_primary_url?: string | null;
+  cta_secondary_label?: string | null;
+  cta_secondary_url?: string | null;
+  career_cta_label?: string | null;
+  career_cta_url?: string | null;
   created_at: string;
   updated_at: string;
 };


### PR DESCRIPTION
## Summary
- redesign the public profile page with a banner-style hero, philosophy section, expertise pillars, timeline, speaking, recognition, testimonials, and personal cards sourced from Supabase
- add admin managers and server actions to curate pillars, career highlights, speaking engagements, recognition, testimonials, and personal entries
- extend Supabase initialization and seed scripts with the supporting tables, policies, and demo data for the new sections

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ddbd6b8ba88325a2842fa67d118928